### PR TITLE
build: android support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,11 +1,5 @@
 VPATH=%VPATH%
 
-CXX ?= g++
-RUSTC ?= rustc
-AR ?= ar
-RUSTFLAGS ?=
-CFLAGS += -fPIC
-
 ifeq ($(shell $(CXX) -v 2>&1 | grep -c 'clang version\|Apple.*clang'),1)
 CFLAGS += -Wno-c++0x-extensions -Wno-return-type-c-linkage -Wno-invalid-offsetof
 endif

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 SRCDIR="$(cd $(dirname $0) && pwd)"
-sed "s#%VPATH%#${SRCDIR}#" ${SRCDIR}/Makefile.in > Makefile
+sed -e "s#%VPATH%#${SRCDIR}#" ${SRCDIR}/Makefile.in > Makefile

--- a/js.rc
+++ b/js.rc
@@ -75,12 +75,31 @@ pub static JSVAL_ONE: u64 = ((JSVAL_TAG_MAX_DOUBLE | JSVAL_TYPE_INT32) << JSVAL_
 pub static JSVAL_FALSE: u64 = (JSVAL_TAG_MAX_DOUBLE | JSVAL_TYPE_BOOLEAN) << JSVAL_TAG_SHIFT;
 pub static JSVAL_TRUE: u64 = ((JSVAL_TAG_MAX_DOUBLE | JSVAL_TYPE_BOOLEAN) << JSVAL_TAG_SHIFT) | 1;
 
+#[cfg(not(target_os = "android"))]
 pub static JSID_TYPE_STRING: i64 = 0;
+#[cfg(not(target_os = "android"))]
 pub static JSID_TYPE_INT: i64 = 1;
+#[cfg(not(target_os = "android"))]
 pub static JSID_TYPE_VOID: i64 = 2;
+#[cfg(not(target_os = "android"))]
 pub static JSID_TYPE_OBJECT: i64 = 4;
+#[cfg(not(target_os = "android"))]
 pub static JSID_TYPE_DEFAULT_XML_NAMESPACE: i64 = 6;
+#[cfg(not(target_os = "android"))]
 pub static JSID_TYPE_MASK: i64 = 7;
+
+#[cfg(target_os = "android")]
+pub static JSID_TYPE_STRING: i32 = 0;
+#[cfg(target_os = "android")]
+pub static JSID_TYPE_INT: i32 = 1;
+#[cfg(target_os = "android")]
+pub static JSID_TYPE_VOID: i32 = 2;
+#[cfg(target_os = "android")]
+pub static JSID_TYPE_OBJECT: i32 = 4;
+#[cfg(target_os = "android")]
+pub static JSID_TYPE_DEFAULT_XML_NAMESPACE: i32 = 6;
+#[cfg(target_os = "android")]
+pub static JSID_TYPE_MASK: i32 = 7;
 
 pub static JSID_VOID: jsid = JSID_TYPE_VOID;
 

--- a/linkhack.rs
+++ b/linkhack.rs
@@ -13,3 +13,8 @@ extern mod m { }
 #[link_args = "-L. -ljs_static -lstdc++ -lz"]
 #[nolink]
 extern mod m { }
+
+#[cfg(target_os = "android")]
+#[link_args = "-L. -ljs_static -lmozjs -lstdc++ -lz"]
+#[nolink]
+extern mod m { }


### PR DESCRIPTION
android port preparation
1. additional submodule required for android
   fontconfig, libexpat, libfreetype2
2. It might need to update submodule and servo at once 
