### PR TITLE
support android build

### DIFF
--- a/js.rc
+++ b/js.rc
@@ -99,7 +99,7 @@ pub static JSID_TYPE_OBJECT: i64 = 4;
 pub static JSID_TYPE_DEFAULT_XML_NAMESPACE: i64 = 6;
 pub static JSID_TYPE_MASK: i64 = 7;
 
-pub static JSID_VOID: jsid = JSID_TYPE_VOID;
+pub static JSID_VOID: jsid = JSID_TYPE_VOID as jsid;
 
 pub static JSFUN_CONSTRUCTOR: u32 = 0x200; /* native that can be called as a ctor */
 

--- a/linkhack.rs
+++ b/linkhack.rs
@@ -13,3 +13,11 @@ extern { }
 #[link_args = "-L. -ljs_static -lstdc++ -lz"]
 #[nolink]
 extern { }
+
+//Avoid hard linking with stdc++ in android ndk cross toolchain
+//It is hard to find location of android system libs in this rust source file
+//and also we need to size down for mobile app packaging
+#[cfg(target_os = "android")]
+#[link_args = "-L. -lmozjs -lstdc++ -lz"]
+#[nolink]
+extern { }


### PR DESCRIPTION
support android build
This commit does not affect to each submodule's original standalone build system.
Fixed type mismatch on 32bit system. 
