### PR TITLE
This adds an assert function to the JavaScript global similar to assert ...

### DIFF
--- a/global.rs
+++ b/global.rs
@@ -19,12 +19,13 @@ use std::ptr::null;
 use std::ptr;
 use jsapi;
 use jsapi::{JSClass, JSContext, JSVal, JSFunctionSpec, JSBool, JSNativeWrapper};
-use jsapi::{JS_EncodeString, JS_free, JS_ValueToString};
+use jsapi::{JS_EncodeString, JS_free, JS_ValueToBoolean, JS_ValueToString};
+use jsapi::{JS_ReportError, JS_ValueToSource};
 use JSCLASS_IS_GLOBAL;
 use JSCLASS_HAS_RESERVED_SLOTS;
 use JSCLASS_GLOBAL_SLOT_COUNT;
 use JS_ARGV;
-use JSVAL_NULL;
+use JSVAL_VOID;
 use JS_SET_RVAL;
 
 pub fn basic_class(np: @mut NamePool, name: ~str) -> JSClass {
@@ -77,7 +78,39 @@ pub extern fn debug(cx: *JSContext, argc: c_uint, vp: *JSVal) -> JSBool {
             let jsstr = JS_ValueToString(cx, *ptr::offset(argv, i));
             debug!("%s", jsval_to_rust_str(cx, jsstr));
         }
-        JS_SET_RVAL(cx, vp, JSVAL_NULL);
+        JS_SET_RVAL(cx, vp, JSVAL_VOID);
+        return 1_i32;
+    }
+}
+
+pub extern fn assert(cx: *JSContext, argc: c_uint, vp: *JSVal) -> JSBool {
+    unsafe {
+        let argv = JS_ARGV(cx, vp);
+
+        let argument = match argc {
+            0 => JSVAL_VOID,
+            _ => *ptr::offset(argv, 0)
+        };
+
+        let result = 0;
+        if JS_ValueToBoolean(cx, argument, &result) == 0 {
+            return 0_i32;
+        }
+
+        if result == 0 {
+            // This operation can fail, but that is not critical.
+            let source = JS_ValueToSource(cx, argument);
+            let msg = fmt!("JavaScript assertion failed: %s is falsy!",
+                            jsval_to_rust_str(cx, source));
+
+            debug!(msg);
+            do msg.to_c_str().with_ref |buf| {
+              JS_ReportError(cx, buf);
+            }
+            return 0_i32;
+        }
+
+        JS_SET_RVAL(cx, vp, JSVAL_VOID);
         return 1_i32;
     }
 }
@@ -91,6 +124,16 @@ pub fn debug_fns(np: @mut NamePool) -> ~[JSFunctionSpec] {
                 info: null()
             },
             nargs: 0,
+            flags: 0,
+            selfHostedName: null()
+        },
+        JSFunctionSpec {
+            name: np.add(~"assert"),
+            call: JSNativeWrapper {
+                op: assert,
+                info: null()
+            },
+            nargs: 1,
             flags: 0,
             selfHostedName: null()
         },


### PR DESCRIPTION
...in Rust. This function can be used for writing tests.

This previously was pull request #28, but I had to fix up a lot of stuff. I hope in the future I can get a more proper git workflow going. 
