### PR TITLE
In Int32Value, cast to u32 before casting to u64.

### DIFF
--- a/jsval.rs
+++ b/jsval.rs
@@ -81,7 +81,7 @@ pub fn UndefinedValue() -> JSVal {
 
 #[inline(always)]
 pub fn Int32Value(i: i32) -> JSVal {
-    BuildJSVal(JSVAL_TAG_INT32, i as u64)
+    BuildJSVal(JSVAL_TAG_INT32, i as u32 as u64)
 }
 
 #[inline(always)]


### PR DESCRIPTION
Casting to u64 directly is equivalent to first casting to i64, which does
sign extension. For negative values, this fills the highest 32 bits with
ones rather than the zeros we need.
