### PR TITLE
Android support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -33,4 +33,4 @@ check: js-test
 
 .PHONY: clean
 clean:
-	rm -f js-test *.o *.a *.so *.dylib *.dll *.dummy
+	rm -f js-test *.o *.a *.so *.dylib *.rlib *.dll *.dummy

--- a/glue.rs
+++ b/glue.rs
@@ -51,7 +51,15 @@ pub struct ProxyTraps {
     trace: Option<extern "C" fn(*mut JSTracer, *JSObject)>
 }
 
+#[cfg(not(target_os = "android"))]
 #[link(name = "jsglue")]
+extern { }
+
+
+#[cfg(target_os = "android")]
+#[link_args = "-ljsglue -lstdc++ -lgcc"]
+extern { }
+
 extern {
 
 // FIXME: Couldn't run on rust_stack until rust issue #6470 fixed.

--- a/js.rc
+++ b/js.rc
@@ -7,7 +7,7 @@
 #[crate_type = "dylib"];
 #[crate_type = "rlib"];
 
-#[feature(globs, managed_boxes)];
+#[feature(globs, link_args, managed_boxes)];
 
 #[allow(non_uppercase_statics, non_camel_case_types)];
 

--- a/linkhack.rs
+++ b/linkhack.rs
@@ -17,11 +17,13 @@ extern { }
 #[link(name = "z")]
 extern { }
 
-//Avoid hard linking with stdc++ in android ndk cross toolchain
+// Avoid hard linking with stdc++ in android ndk cross toolchain so that
+// the ELF header will have an entry for libstdc++ and we will know to
+// open it explicitly.
 //It is hard to find location of android system libs in this rust source file
 //and also we need to size down for mobile app packaging
 #[cfg(target_os = "android")]
-#[link(name = "js_static")]
-#[link(name = "stdc++")]
+#[link(name = "mozjs")]
+#[link_args="-lstdc++"]
 #[link(name = "z")]
 extern { }


### PR DESCRIPTION
1) Add dylib generation 
2) Address linker issues on Android (i.e., #[link] is not emitting fully-named dependencies in the ELF header, requiring us to use #[link_name] in order to properly find and load all dependencies the .so file has)

r? @jdm @metajack
