### PR TITLE
Fix accidental shadowing of js_GetErrorMessage

### DIFF
--- a/glue.rs
+++ b/glue.rs
@@ -95,8 +95,8 @@ pub fn DefineFunctionWithReserved(cx: *JSContext, obj: *JSObject,
                                   name: *libc::c_char, call: JSNative, nargs: libc::c_uint,
                                   attrs: libc::c_uint) -> *JSObject;
 pub fn GetObjectJSClass(obj: *JSObject) -> *JSClass;
-pub fn js_GetErrorMessage(userRef: *libc::c_void, locale: *libc::c_char,
-                          errorNumber: libc::c_uint) -> *JSErrorFormatString;
+pub fn RUST_js_GetErrorMessage(userRef: *libc::c_void, locale: *libc::c_char,
+                               errorNumber: libc::c_uint) -> *JSErrorFormatString;
 pub fn js_IsObjectProxyClass(obj: *JSObject) -> bool;
 pub fn js_IsFunctionProxyClass(obj: *JSObject) -> bool;
 pub fn IsProxyHandlerFamily(obj: *JSObject) -> bool;

--- a/jsglue.cpp
+++ b/jsglue.cpp
@@ -406,8 +406,8 @@ GetObjectJSClass(JSObject* obj)
     return js::GetObjectJSClass(obj);
 }
 
-JSErrorFormatString*
-js_GetErrorMessage(void* userRef, char* locale, uint32_t errorNumber)
+const JSErrorFormatString*
+RUST_js_GetErrorMessage(void* userRef, char* locale, uint32_t errorNumber)
 {
     return js_GetErrorMessage(userRef, locale, errorNumber);
 }


### PR DESCRIPTION
jsglue.cpp defines a function with the same name of the jsapi function it tries to wrap, causing a probable infinite loop.
