### PR TITLE
Work around dynamic linking problems on Android

### DIFF
--- a/glue.rs
+++ b/glue.rs
@@ -44,13 +44,12 @@ pub struct ProxyTraps {
     trace: Option<extern "C" fn(*mut JSTracer, *JSObject)>
 }
 
-#[cfg(not(target_os = "android"))]
 #[link(name = "jsglue")]
 extern { }
 
 
 #[cfg(target_os = "android")]
-#[link_args = "-ljsglue -lstdc++ -lgcc"]
+#[link_args = "-ljsglue -lstdc++ -lgcc -rdynamic"]
 extern { }
 
 extern {


### PR DESCRIPTION
This fixes a "symbol not found error" from dlopen on Android.  However, I don't fully understand the underlying cause of the bug or why this fixes it.  I think it might be related to a change in the order of linker arguments emitted by rustc, possibly related to mozilla-servo/rust-fontconfig#12.
