### PR TITLE
Update Rust

### DIFF
--- a/jsval.rs
+++ b/jsval.rs
@@ -56,7 +56,7 @@ static JSVAL_PAYLOAD_MASK: u64 = 0x00007FFFFFFFFFFF;
 
 // JSVal was originally type of u64.
 // now this become {u64} because of the union abi issue on ARM arch. See #398.
-#[deriving(Eq,Clone)]
+#[deriving(PartialEq,Clone)]
 pub struct JSVal {
     pub v: u64
 }


### PR DESCRIPTION
Brings us to [`9f8d2205f0518389993a9b5de6646ba8b14e5a12`](https://github.com/rust-lang/rust/tree/9f8d2205f0518389993a9b5de6646ba8b14e5a12) (June 17)

See https://github.com/mozilla/servo/pull/2677
