### PR TITLE
Use link instead of link_args on Android

### DIFF
--- a/glue.rs
+++ b/glue.rs
@@ -46,9 +46,12 @@ pub struct ProxyTraps {
 #[link(name = "jsglue")]
 extern { }
 
+#[cfg(target_os = "android")]
+#[link(name = "stdc++")]
+extern { }
 
 #[cfg(target_os = "android")]
-#[link_args = "-ljsglue -lstdc++ -lgcc -rdynamic"]
+#[link(name = "gcc")]
 extern { }
 
 extern {


### PR DESCRIPTION
The previous fix #70 is no longer working on my device after recent Rust upgrades. I get dlopen errors about missing symbols from libstdc++ when loading libscript.  This patch fixes the errors for me. r? @larsbergstrom
