### PR TITLE
Revert <https://github.com/servo/rust-mozjs/pull/92>.

### DIFF
--- a/linkhack.rs
+++ b/linkhack.rs
@@ -6,14 +6,12 @@
 
 #[cfg(target_os = "linux")]
 #[link(name = "pthread")]
-#[link(name = "nspr4")]
 #[link(name = "js_static", kind = "static")]
 #[link(name = "stdc++")]
 #[link(name = "z")]
 extern { }
 
 #[cfg(target_os = "macos")]
-#[link(name = "nspr4")]
 #[link(name = "js_static", kind = "static")]
 #[link(name = "stdc++")]
 #[link(name = "z")]


### PR DESCRIPTION
The Servo changes to move the script task to a native task are not progressing
as fast as hoped, so these changes should be temporarily reverted.
