### PR TITLE
Use Servo fork of green-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ debugmozjs = ['mozjs-sys/debugmozjs']
 git = "https://github.com/servo/mozjs"
 
 [dependencies.green]
-git = "https://github.com/alexcrichton/green-rs"
+git = "https://github.com/servo/green-rs"
+branch = "servo"
 
 [dependencies.rustuv]
-git = "https://github.com/alexcrichton/green-rs"
+git = "https://github.com/servo/green-rs"
+branch = "servo"


### PR DESCRIPTION
Required to pull Android build fixes (alexcrichton/green-rs#3) into a branch that builds with Servo's rust snapshot. r? @jdm 
