### PR TITLE
Get dependency directory from cargo metadata

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -20,8 +20,7 @@ ifneq (,$(CARGO_FEATURE_DEBUGMOZJS))
 	CFLAGS += -g -O0 -DDEBUG -D_DEBUG
 endif
 
-MOZJS_OUTDIR = $(shell find $(OUT_DIR)/../.. -name 'mozjs_sys-*' -type d)/out
-CFLAGS += -I$(MOZJS_OUTDIR)/dist/include
+CFLAGS += -I$(DEP_MOZJS_OUTDIR)/dist/include
 
 .PHONY: all
 all: $(OUT_DIR)/libjsglue.a


### PR DESCRIPTION
Part of servo/servo#6088. Depends on servo/mozjs#38  @SimonSapin