### PR TITLE
Add new feature gates.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@
 #![crate_name = "js"]
 #![crate_type = "rlib"]
 
-#![feature(link_args, collections, core)]
+#![feature(collections, str_utf16)]
+#![feature(core, core_intrinsics)]
+#![feature(link_args)]
 
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case, improper_ctypes, raw_pointer_derive)]
 


### PR DESCRIPTION
The collections and core feature gates have been split up in Rust nightlies.
This allows this library to build with nightly rust as well as the rust in
use with Servo.