### PR TITLE
Add glue to use SpiderMonkey's memory reporting from Rust code.

### DIFF
--- a/src/glue.rs
+++ b/src/glue.rs
@@ -229,4 +229,5 @@ extern "C" {
     pub fn AppendToAutoObjectVector(v: *mut AutoObjectVector,
                                     obj: *mut JSObject) -> u8;
     pub fn DeleteAutoObjectVector(v: *mut AutoObjectVector);
+    pub fn CollectServoSizes(rt: *mut JSRuntime, sizes: *mut ServoSizes) -> bool;
 }

--- a/src/jsapi.rs
+++ b/src/jsapi.rs
@@ -130,6 +130,15 @@ pub enum JSVersion {
     JSVERSION_UNKNOWN = -1,
     JSVERSION_LATEST = 185,
 }
+#[repr(C)]
+pub struct ServoSizes {
+    pub gcHeapUsed: ::libc::size_t,
+    pub gcHeapUnused: ::libc::size_t,
+    pub gcHeapAdmin: ::libc::size_t,
+    pub gcHeapDecommitted: ::libc::size_t,
+    pub mallocHeap: ::libc::size_t,
+    pub nonHeap: ::libc::size_t,
+}
 #[repr(i32)]
 #[derive(Copy, Clone)]
 pub enum JSType {


### PR DESCRIPTION
This cannot land until https://github.com/servo/mozjs/pull/49 has landed. And it must land before https://github.com/servo/servo/pull/6572 can land.