### PR TITLE
Set nativeRegExp to true rather than false.

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -98,6 +98,7 @@ impl Runtime {
             (*runtimeopts).set_varObjFix_(true);
             (*runtimeopts).set_baseline_(true);
             (*runtimeopts).set_ion_(true);
+            (*runtimeopts).set_nativeRegExp_(true);
 
             (*contextopts).set_dontReportUncaught_(true);
             (*contextopts).set_autoJSAPIOwnsErrorReporting_(true);


### PR DESCRIPTION
Improves SpiderMonkey regex performance, and gives us the same default as Firefox.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/210)
<!-- Reviewable:end -->
