### PR TITLE
Removed gczeal bindings.

### DIFF
--- a/src/jsapi_linux_32.rs
+++ b/src/jsapi_linux_32.rs
@@ -5108,13 +5108,6 @@ extern "C" {
     pub fn JS_NewObjectForConstructor(cx: *mut JSContext,
                                       clasp: *const JSClass,
                                       args: *const CallArgs) -> *mut JSObject;
-    #[link_name = "_Z12JS_GetGCZealP9JSContextPhPjS2_"]
-    pub fn JS_GetGCZeal(cx: *mut JSContext, zeal: *mut u8,
-                        frequency: *mut u32, nextScheduled: *mut u32);
-    #[link_name = "_Z12JS_SetGCZealP9JSContexthj"]
-    pub fn JS_SetGCZeal(cx: *mut JSContext, zeal: u8, frequency: u32);
-    #[link_name = "_Z13JS_ScheduleGCP9JSContextj"]
-    pub fn JS_ScheduleGC(cx: *mut JSContext, count: u32);
     #[link_name = "_Z28JS_SetParallelParsingEnabledP9JSRuntimeb"]
     pub fn JS_SetParallelParsingEnabled(rt: *mut JSRuntime, enabled: bool);
     #[link_name = "_Z36JS_SetOffthreadIonCompilationEnabledP9JSRuntimeb"]

--- a/src/jsapi_linux_64.rs
+++ b/src/jsapi_linux_64.rs
@@ -5108,13 +5108,6 @@ extern "C" {
     pub fn JS_NewObjectForConstructor(cx: *mut JSContext,
                                       clasp: *const JSClass,
                                       args: *const CallArgs) -> *mut JSObject;
-    #[link_name = "_Z12JS_GetGCZealP9JSContextPhPjS2_"]
-    pub fn JS_GetGCZeal(cx: *mut JSContext, zeal: *mut u8,
-                        frequency: *mut u32, nextScheduled: *mut u32);
-    #[link_name = "_Z12JS_SetGCZealP9JSContexthj"]
-    pub fn JS_SetGCZeal(cx: *mut JSContext, zeal: u8, frequency: u32);
-    #[link_name = "_Z13JS_ScheduleGCP9JSContextj"]
-    pub fn JS_ScheduleGC(cx: *mut JSContext, count: u32);
     #[link_name = "_Z28JS_SetParallelParsingEnabledP9JSRuntimeb"]
     pub fn JS_SetParallelParsingEnabled(rt: *mut JSRuntime, enabled: bool);
     #[link_name = "_Z36JS_SetOffthreadIonCompilationEnabledP9JSRuntimeb"]

--- a/src/jsapi_macos_64.rs
+++ b/src/jsapi_macos_64.rs
@@ -5108,13 +5108,6 @@ extern "C" {
     pub fn JS_NewObjectForConstructor(cx: *mut JSContext,
                                       clasp: *const JSClass,
                                       args: *const CallArgs) -> *mut JSObject;
-    #[link_name = "_Z12JS_GetGCZealP9JSContextPhPjS2_"]
-    pub fn JS_GetGCZeal(cx: *mut JSContext, zeal: *mut u8,
-                        frequency: *mut u32, nextScheduled: *mut u32);
-    #[link_name = "_Z12JS_SetGCZealP9JSContexthj"]
-    pub fn JS_SetGCZeal(cx: *mut JSContext, zeal: u8, frequency: u32);
-    #[link_name = "_Z13JS_ScheduleGCP9JSContextj"]
-    pub fn JS_ScheduleGC(cx: *mut JSContext, count: u32);
     #[link_name = "_Z28JS_SetParallelParsingEnabledP9JSRuntimeb"]
     pub fn JS_SetParallelParsingEnabled(rt: *mut JSRuntime, enabled: bool);
     #[link_name = "_Z36JS_SetOffthreadIonCompilationEnabledP9JSRuntimeb"]

--- a/src/jsapi_windows_gcc_64.rs
+++ b/src/jsapi_windows_gcc_64.rs
@@ -5108,13 +5108,6 @@ extern "C" {
     pub fn JS_NewObjectForConstructor(cx: *mut JSContext,
                                       clasp: *const JSClass,
                                       args: *const CallArgs) -> *mut JSObject;
-    #[link_name = "_Z12JS_GetGCZealP9JSContextPhPjS2_"]
-    pub fn JS_GetGCZeal(cx: *mut JSContext, zeal: *mut u8,
-                        frequency: *mut u32, nextScheduled: *mut u32);
-    #[link_name = "_Z12JS_SetGCZealP9JSContexthj"]
-    pub fn JS_SetGCZeal(cx: *mut JSContext, zeal: u8, frequency: u32);
-    #[link_name = "_Z13JS_ScheduleGCP9JSContextj"]
-    pub fn JS_ScheduleGC(cx: *mut JSContext, count: u32);
     #[link_name = "_Z28JS_SetParallelParsingEnabledP9JSRuntimeb"]
     pub fn JS_SetParallelParsingEnabled(rt: *mut JSRuntime, enabled: bool);
     #[link_name = "_Z36JS_SetOffthreadIonCompilationEnabledP9JSRuntimeb"]


### PR DESCRIPTION
PR https://github.com/servo/mozjs/pull/60 removes gczeal in release builds.
This gets about a 5% speedup in some Dromaeo JS tests.
Unfortunately, it leaves some dangling symbols that are in the jsapi_ARCH.rs
files, but hace no matching jsapi definitions. This commit removes those
definitions from the bindings.

See https://github.com/servo/mozjs/pull/60#issuecomment-153920443

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/212)
<!-- Reviewable:end -->
