### PR TITLE
Use libc types from the top level module rather than types::os::arch::c95.

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -4,8 +4,7 @@
 
 //! Rust wrappers around the raw JS apis
 
-use libc::types::os::arch::c95::{size_t, c_uint};
-use libc::c_char;
+use libc::{size_t, c_uint, c_char};
 use std::char;
 use std::ffi;
 use std::ptr;


### PR DESCRIPTION
The inner modules will be removed in libc 0.2.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/214)
<!-- Reviewable:end -->
