### PR TITLE
Rename CallArgs::{get, get_mut} to {index, index_mut}.

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -572,14 +572,14 @@ impl CallArgs {
         }
     }
 
-    pub fn get(&self, i: u32) -> HandleValue {
+    pub fn index(&self, i: u32) -> HandleValue {
         assert!(i < self._base.argc_);
         unsafe {
             HandleValue::from_marked_location(self._base._base.argv_.offset(i as isize))
         }
     }
 
-    pub fn get_mut(&self, i: u32) -> MutableHandleValue {
+    pub fn index_mut(&self, i: u32) -> MutableHandleValue {
         assert!(i < self._base.argc_);
         unsafe {
             MutableHandleValue::from_marked_location(self._base._base.argv_.offset(i as isize))

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -586,6 +586,16 @@ impl CallArgs {
         }
     }
 
+    pub fn get(&self, i: u32) -> HandleValue {
+        unsafe {
+            if i < self._base.argc_ {
+                HandleValue::from_marked_location(self._base._base.argv_.offset(i as isize))
+            } else {
+                UndefinedHandleValue
+            }
+        }
+    }
+
     pub fn rval(&self) -> MutableHandleValue {
         unsafe {
             MutableHandleValue::from_marked_location(self._base._base.argv_.offset(-2))


### PR DESCRIPTION
CallArgs::get exists in C++ with different semantics. It is confusing to have
it exist in this form.

Fixes #219.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/220)
<!-- Reviewable:end -->
