### PR TITLE
Replicate CallArgs::{get, index, index_mut} onto JSJitMethodCallArgs

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -537,13 +537,23 @@ impl Drop for JSAutoCompartment {
 
 impl JSJitMethodCallArgs {
     pub fn get(&self, i: u32) -> HandleValue {
+        unsafe {
+            if i < self._base.argc_ {
+                HandleValue::from_marked_location(self._base._base.argv_.offset(i as isize))
+            } else {
+                UndefinedHandleValue
+            }
+        }
+    }
+
+    pub fn index(&self, i: u32) -> HandleValue {
         assert!(i < self._base.argc_);
         unsafe {
             HandleValue::from_marked_location(self._base._base.argv_.offset(i as isize))
         }
     }
 
-    pub fn get_mut(&self, i: u32) -> MutableHandleValue {
+    pub fn index_mut(&self, i: u32) -> MutableHandleValue {
         assert!(i < self._base.argc_);
         unsafe {
             MutableHandleValue::from_marked_location(self._base._base.argv_.offset(i as isize))


### PR DESCRIPTION
This solves the problem of servo/servo#8854 where I can't use `.index()` on some args values because the type of args is `JSJitMethodCallArgs` instead of `CallArgs`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/223)
<!-- Reviewable:end -->
