### PR TITLE
Initial implementation for sequence arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,9 @@ pub mod glue;
 pub mod jsval;
 pub mod rust;
 
+#[cfg(test)]
+mod tests;
+
 pub use consts::*;
 
 use heapsize::HeapSizeOf;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,61 @@
+
+use consts::{JSCLASS_RESERVED_SLOTS_MASK,JSCLASS_RESERVED_SLOTS_SHIFT,JSCLASS_GLOBAL_SLOT_COUNT,JSCLASS_IS_GLOBAL};
+use jsapi::JS_GlobalObjectTraceHook;
+use conversions::*;
+use jsval::*;
+use rust::*;
+use jsapi::{CallArgs,CompartmentOptions,OnNewGlobalHookOption,Rooted,Value, JS_NewGlobalObject};
+use jsapi::{RootedValue, RootedObject, JSAutoRequest, JSAutoCompartment, JS_Init, JSClass};
+use std::ptr;
+
+static CLASS: &'static JSClass = &JSClass {
+    name: b"test\0" as *const u8 as *const _,
+    flags: JSCLASS_IS_GLOBAL | ((JSCLASS_GLOBAL_SLOT_COUNT & JSCLASS_RESERVED_SLOTS_MASK) << JSCLASS_RESERVED_SLOTS_SHIFT),
+    addProperty: None,
+    delProperty: None,
+    getProperty: None,
+    setProperty: None,
+    enumerate: None,
+    resolve: None,
+    convert: None,
+    finalize: None,
+    call: None,
+    hasInstance: None,
+    construct: None,
+    trace: Some(JS_GlobalObjectTraceHook),
+    reserved: [0 as *mut _; 25]
+};
+
+
+#[test]
+fn test_vec_conversion() {
+    unsafe{
+        assert!(JS_Init());
+    }
+
+    let rt = Runtime::new();
+    let cx = rt.cx();
+
+    let glob = RootedObject::new(cx, 0 as *mut _);
+    let _ar = JSAutoRequest::new(cx);
+
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = CompartmentOptions::default();
+    let global = unsafe {
+        JS_NewGlobalObject(cx, CLASS, ptr::null_mut(), h_option, &c_option)
+    };
+    let global_root = Rooted::new(cx, global);
+    let global = global_root.handle();
+
+    let _ac = JSAutoCompartment::new(cx, global.get());
+
+    let orig_vec: Vec<f32> = vec![1.0, 2.9, 3.0];
+    let mut rval = RootedValue::new(cx, UndefinedValue());
+
+    let converted = unsafe {
+        orig_vec.to_jsval(cx, rval.handle_mut());
+        Vec::<f32>::from_jsval(cx, rval.handle(), ()).unwrap()
+    };
+
+    assert_eq!(orig_vec, converted);
+}


### PR DESCRIPTION
This was the initial implementation for sequence arguments, working for JS arrays, with a test, as requested by @nox.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/229)
<!-- Reviewable:end -->
