### PR TITLE
conversions: Make the config param generic

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -106,7 +106,7 @@ pub trait FromJSValConvertible: Sized {
 }
 
 /// Behavior for converting out-of-range integers.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum ConversionBehavior {
     /// Wrap into the integer's range.
     Default,
@@ -489,12 +489,12 @@ impl<T: ToJSValConvertible> ToJSValConvertible for Vec<T> {
     }
 }
 
-impl<T: FromJSValConvertible<Config=()>> FromJSValConvertible for Vec<T> {
-    type Config = ();
+impl<C: Clone, T: FromJSValConvertible<Config=C>> FromJSValConvertible for Vec<T> {
+    type Config = C;
 
     unsafe fn from_jsval(cx: *mut JSContext,
                          value: HandleValue,
-                         option: ())
+                         option: C)
                          -> Result<Vec<T>, ()> {
         let mut length = 0;
 
@@ -510,7 +510,7 @@ impl<T: FromJSValConvertible<Config=()>> FromJSValConvertible for Vec<T> {
             for i in 0..length {
                 let mut val = RootedValue::new(cx, UndefinedValue());
                 assert!(JS_GetElement(cx, handle_obj, i, val.handle_mut()));
-                ret.push(try!(T::from_jsval(cx, val.handle(), option)));
+                ret.push(try!(T::from_jsval(cx, val.handle(), option.clone())));
             }
 
             Ok(ret)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -49,12 +49,20 @@ fn test_vec_conversion() {
 
     let _ac = JSAutoCompartment::new(cx, global.get());
 
-    let orig_vec: Vec<f32> = vec![1.0, 2.9, 3.0];
     let mut rval = RootedValue::new(cx, UndefinedValue());
 
+    let orig_vec: Vec<f32> = vec![1.0, 2.9, 3.0];
     let converted = unsafe {
         orig_vec.to_jsval(cx, rval.handle_mut());
         Vec::<f32>::from_jsval(cx, rval.handle(), ()).unwrap()
+    };
+
+    assert_eq!(orig_vec, converted);
+
+    let orig_vec: Vec<i32> = vec![1, 2, 3];
+    let converted = unsafe {
+        orig_vec.to_jsval(cx, rval.handle_mut());
+        Vec::<i32>::from_jsval(cx, rval.handle(), ConversionBehavior::Default).unwrap()
     };
 
     assert_eq!(orig_vec, converted);


### PR DESCRIPTION
This allows to convert all types, not just those with `Config=()`.

This flaw was discovered while adding tests for it in `TestBindings`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/230)
<!-- Reviewable:end -->
