### PR TITLE
Updated pub/priv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,19 +24,19 @@ extern crate rustc_serialize as serialize;
 
 #[cfg(target_os = "linux")]
 #[cfg(target_pointer_width = "64")]
-mod jsapi_linux_64;
+pub mod jsapi_linux_64;
 
 #[cfg(target_os = "macos")]
 #[cfg(target_pointer_width = "64")]
-mod jsapi_macos_64;
+pub mod jsapi_macos_64;
 
 #[cfg(target_os = "windows")]
 #[cfg(target_pointer_width = "64")]
-mod jsapi_windows_gcc_64;
+pub mod jsapi_windows_gcc_64;
 
 #[cfg(not(target_os = "windows"))]
 #[cfg(target_pointer_width = "32")]
-mod jsapi_linux_32;
+pub mod jsapi_linux_32;
 
 pub mod jsapi {
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
If you try to wrap the `<js::jsapi::Handle<T>>` class. You can't actually do this because the T type is platform specific, AND private. 

The example use case can be seen here: https://github.com/valarauca/lib_js/blob/feda0234c91901a606fcbccdef6b386374955a21/src/lib.rs#L21-L28

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/234)
<!-- Reviewable:end -->
