### PR TITLE
Remove redundant default build/test instructions on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ dist: trusty
 rust:
   - nightly
 
-script:
-  - cargo build --verbose
-  - cargo test --verbose
 branches:
   except:
     - master


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/245)
<!-- Reviewable:end -->
