### PR TITLE
Allow evaluate_script to return values

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -21,7 +21,7 @@ use jsapi;
 use jsapi::{JS_NewContext, JS_DestroyContext, JS_NewRuntime, JS_DestroyRuntime};
 use jsapi::{JSContext, JSRuntime, JSObject, JSFlatString, JSFunction, JSString, Symbol, JSScript, jsid, Value};
 use jsapi::{RuntimeOptionsRef, ContextOptionsRef, ReadOnlyCompileOptions};
-use jsapi::{JS_SetErrorReporter, Evaluate3, JSErrorReport};
+use jsapi::{JS_SetErrorReporter, Evaluate2, JSErrorReport};
 use jsapi::{JS_SetGCParameter, JSGCParamKey};
 use jsapi::{JSWhyMagic, Heap, Cell, HeapObjectPostBarrier, HeapValuePostBarrier};
 use jsapi::{ContextFriendFields};
@@ -180,12 +180,8 @@ impl Runtime {
         let _ac = JSAutoCompartment::new(self.cx(), glob.get());
         let options = CompileOptionsWrapper::new(self.cx(), filename_cstr.as_ptr(), line_num);
 
-        let scopechain = AutoObjectVectorWrapper::new(self.cx());
-
         unsafe {
-            if !Evaluate3(self.cx(), scopechain.ptr, options.ptr,
-                          ptr as *const u16, len as size_t,
-                          rval) {
+            if !Evaluate2(self.cx(), options.ptr, ptr as *const u16, len as size_t, rval) {
                 debug!("...err!");
                 Err(())
             } else {

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -162,7 +162,8 @@ impl Runtime {
         self.cx
     }
 
-    pub fn evaluate_script(&self, glob: HandleObject, script: String, filename: String, line_num: u32)
+    pub fn evaluate_script(&self, glob: HandleObject, script: &str, filename: &str,
+                           line_num: u32, rval: MutableHandleValue)
                     -> Result<(),()> {
         let script_utf16: Vec<u16> = script.encode_utf16().collect();
         let filename_cstr = ffi::CString::new(filename.as_bytes()).unwrap();
@@ -181,12 +182,10 @@ impl Runtime {
 
         let scopechain = AutoObjectVectorWrapper::new(self.cx());
 
-        let mut rval = RootedValue::new(self.cx(), UndefinedValue());
-
         unsafe {
             if !Evaluate3(self.cx(), scopechain.ptr, options.ptr,
                           ptr as *const u16, len as size_t,
-                          rval.handle_mut()) {
+                          rval) {
                 debug!("...err!");
                 Err(())
             } else {

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -17,6 +17,7 @@ use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::JS_ReportError;
 use js::jsapi::OnNewGlobalHookOption;
 use js::jsapi::Rooted;
+use js::jsapi::RootedValue;
 use js::jsapi::Value;
 use js::jsval::UndefinedValue;
 use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
@@ -43,8 +44,9 @@ fn callback() {
         let function = JS_DefineFunction(context, global, b"puts\0".as_ptr() as *const libc::c_char,
                                          Some(puts), 1, 0);
         assert!(!function.is_null());
-        let javascript = "puts('Test Iñtërnâtiônàlizætiøn ┬─┬ノ( º _ ºノ) ');".to_string();
-        let _ = runtime.evaluate_script(global, javascript, "test.js".to_string(), 0);
+        let javascript = "puts('Test Iñtërnâtiônàlizætiøn ┬─┬ノ( º _ ºノ) ');";
+        let mut rval = RootedValue::new(runtime.cx(), UndefinedValue());
+        let _ = runtime.evaluate_script(global, javascript, "test.js", 0, rval.handle_mut());
     }
 }
 

--- a/tests/evaluate.rs
+++ b/tests/evaluate.rs
@@ -11,6 +11,8 @@ use js::jsapi::JS_Init;
 use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::OnNewGlobalHookOption;
 use js::jsapi::RootedObject;
+use js::jsapi::RootedValue;
+use js::jsval::UndefinedValue;
 use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
 
 use std::ptr;
@@ -28,7 +30,8 @@ fn evaluate() {
                                OnNewGlobalHookOption::FireOnNewGlobalHook,
                                &CompartmentOptions::default())
         );
-        assert!(rt.evaluate_script(global.handle(), "1 + 1".to_owned(),
-                                   "test".to_owned(), 1).is_ok());
+        let mut rval = RootedValue::new(cx, UndefinedValue());
+        assert!(rt.evaluate_script(global.handle(), "1 + 1",
+                                   "test", 1, rval.handle_mut()).is_ok());
     }
 }

--- a/tests/stack_limit.rs
+++ b/tests/stack_limit.rs
@@ -10,6 +10,8 @@ use js::jsapi::JS_Init;
 use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::OnNewGlobalHookOption;
 use js::jsapi::Rooted;
+use js::jsapi::RootedValue;
+use js::jsval::UndefinedValue;
 use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
 
 use std::ptr;
@@ -29,10 +31,8 @@ fn stack_limit() {
                                         ptr::null_mut(), h_option, &c_option);
         let global_root = Rooted::new(cx, global);
         let global = global_root.handle();
-
-        assert!(rt.evaluate_script(global,
-                                   "function f() { f.apply() } f()".to_string(),
-                                   "test".to_string(),
-                                   1).is_err());
+        let mut rval = RootedValue::new(cx, UndefinedValue());
+        assert!(rt.evaluate_script(global, "function f() { f.apply() } f()",
+                                   "test", 1, rval.handle_mut()).is_err());
     }
 }


### PR DESCRIPTION
This includes some other minor cleanups. This is a port of @tschneidereit's commits from this branch:
https://github.com/tschneidereit/rust-mozjs/tree/update-bindings

This is need to get https://github.com/tschneidereit/mozjs-shell  working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/258)
<!-- Reviewable:end -->
