### PR TITLE
Change Runtime::new to take a parent runtime

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -116,8 +116,8 @@ impl Runtime {
     ///
     /// Calling this function concurrently can cause segfaults inside
     /// SpiderMonkey
-    pub unsafe fn new() -> Runtime {
-        let js_runtime = JS_NewRuntime(default_heapsize, ChunkSize as u32, ptr::null_mut());
+    pub unsafe fn new(parent_rt: *mut JSRuntime) -> Runtime {
+        let js_runtime = JS_NewRuntime(default_heapsize, ChunkSize as u32, parent_rt);
         assert!(!js_runtime.is_null());
 
         // Unconstrain the runtime's threshold on nominal heap size, to avoid

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -30,7 +30,7 @@ fn callback() {
     unsafe {
         JS_Init();
 
-        let runtime = Runtime::new();
+        let runtime = Runtime::new(ptr::null_mut());
         let context = runtime.cx();
 
         let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;

--- a/tests/evaluate.rs
+++ b/tests/evaluate.rs
@@ -19,7 +19,7 @@ use std::ptr;
 fn evaluate() {
     unsafe {
         assert!(JS_Init());
-        let rt = Runtime::new();
+        let rt = Runtime::new(ptr::null_mut());
         let cx = rt.cx();
 
         let global = RootedObject::new(cx,

--- a/tests/stack_limit.rs
+++ b/tests/stack_limit.rs
@@ -20,7 +20,7 @@ fn stack_limit() {
     unsafe {
         assert!(JS_Init());
 
-        let rt = Runtime::new();
+        let rt = Runtime::new(ptr::null_mut());
         let cx = rt.cx();
 
         let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;

--- a/tests/vec_conversion.rs
+++ b/tests/vec_conversion.rs
@@ -25,7 +25,7 @@ fn vec_conversion() {
     unsafe {
         assert!(JS_Init());
 
-        let rt = Runtime::new();
+        let rt = Runtime::new(ptr::null_mut());
         let cx = rt.cx();
 
         let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;


### PR DESCRIPTION
SpiderMonkey shares some data, such as the self-hosting compartment and read-only atoms, between runtimes - but only if a parent runtime is passed when calling `JS_NewRuntime`. This is important for both memory usage and performance: compiling the self-hosted JS takes more than 30ms on a desktop machine, so doing that every time, say, a worker is created is quite wasteful.

r? @nox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/265)
<!-- Reviewable:end -->
