### PR TITLE
Replace return_address usage in Rooted with a stack guard and a rooted! macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 #![crate_name = "js"]
 #![crate_type = "rlib"]
 
-#![feature(core_intrinsics)]
 #![feature(filling_drop)]
 #![feature(link_args)]
 #![feature(unsafe_no_drop_flag)]
@@ -78,12 +77,15 @@ pub mod jsapi {
     include!("jsapi_linux_32_debug.rs");
 }
 
+#[macro_use]
+pub mod rust;
+
 mod consts;
 pub mod conversions;
 pub mod error;
 pub mod glue;
 pub mod jsval;
-pub mod rust;
+
 
 pub use consts::*;
 

--- a/tests/evaluate.rs
+++ b/tests/evaluate.rs
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[macro_use]
 extern crate js;
 
 use js::jsapi::CompartmentOptions;
 use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::OnNewGlobalHookOption;
-use js::jsapi::RootedObject;
-use js::jsapi::RootedValue;
 use js::jsval::UndefinedValue;
 use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
 
@@ -21,12 +20,12 @@ fn evaluate() {
 
     unsafe {
 
-        let global = RootedObject::new(cx,
+        rooted!(in(cx) let global =
             JS_NewGlobalObject(cx, &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
                                OnNewGlobalHookOption::FireOnNewGlobalHook,
                                &CompartmentOptions::default())
         );
-        let mut rval = RootedValue::new(cx, UndefinedValue());
+        rooted!(in(cx) let mut rval = UndefinedValue());
         assert!(rt.evaluate_script(global.handle(), "1 + 1",
                                    "test", 1, rval.handle_mut()).is_ok());
     }

--- a/tests/stack_limit.rs
+++ b/tests/stack_limit.rs
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[macro_use]
 extern crate js;
 
 use js::jsapi::CompartmentOptions;
 use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::OnNewGlobalHookOption;
-use js::jsapi::Rooted;
-use js::jsapi::RootedValue;
 use js::jsval::UndefinedValue;
 use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
 
@@ -24,9 +23,9 @@ fn stack_limit() {
         let c_option = CompartmentOptions::default();
         let global = JS_NewGlobalObject(cx, &SIMPLE_GLOBAL_CLASS,
                                         ptr::null_mut(), h_option, &c_option);
-        let global_root = Rooted::new(cx, global);
+        rooted!(in(cx) let global_root = global);
         let global = global_root.handle();
-        let mut rval = RootedValue::new(cx, UndefinedValue());
+        rooted!(in(cx) let mut rval = UndefinedValue());
         assert!(rt.evaluate_script(global, "function f() { f.apply() } f()",
                                    "test", 1, rval.handle_mut()).is_err());
     }

--- a/tests/vec_conversion.rs
+++ b/tests/vec_conversion.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[macro_use]
 extern crate js;
 
 use js::conversions::ConversionBehavior;
@@ -12,8 +13,6 @@ use js::jsapi::JSAutoCompartment;
 use js::jsapi::JS_InitStandardClasses;
 use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::OnNewGlobalHookOption;
-use js::jsapi::Rooted;
-use js::jsapi::RootedValue;
 use js::jsval::UndefinedValue;
 use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
 
@@ -30,13 +29,13 @@ fn vec_conversion() {
     unsafe {
         let global = JS_NewGlobalObject(cx, &SIMPLE_GLOBAL_CLASS,
                                         ptr::null_mut(), h_option, &c_option);
-        let global_root = Rooted::new(cx, global);
+        rooted!(in(cx) let global_root = global);
         let global = global_root.handle();
 
         let _ac = JSAutoCompartment::new(cx, global.get());
         assert!(JS_InitStandardClasses(cx, global));
 
-        let mut rval = RootedValue::new(cx, UndefinedValue());
+        rooted!(in(cx) let mut rval = UndefinedValue());
 
         let orig_vec: Vec<f32> = vec![1.0, 2.9, 3.0];
         orig_vec.to_jsval(cx, rval.handle_mut());


### PR DESCRIPTION
Part of a potential solution for rust-lang/rust#34227.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/272)
<!-- Reviewable:end -->
