### PR TITLE
Enable cross-crate inlining for JSVal conversion methods.

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -87,6 +87,7 @@ impl_as!(u64, u64);
 /// A trait to convert Rust types to `JSVal`s.
 pub trait ToJSValConvertible {
     /// Convert `self` to a `JSVal`. JSAPI failure causes a panic.
+    #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue);
 }
 
@@ -155,12 +156,14 @@ fn clamp_to<D>(d: f64) -> D
 
 // https://heycam.github.io/webidl/#es-void
 impl ToJSValConvertible for () {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(UndefinedValue());
     }
 }
 
 impl ToJSValConvertible for JSVal {
+    #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(*self);
         if !JS_WrapValue(cx, rval) {
@@ -170,6 +173,7 @@ impl ToJSValConvertible for JSVal {
 }
 
 impl ToJSValConvertible for HandleValue {
+    #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(self.get());
         if !JS_WrapValue(cx, rval) {
@@ -196,6 +200,7 @@ unsafe fn convert_int_from_jsval<T, M>(cx: *mut JSContext, value: HandleValue,
 
 // https://heycam.github.io/webidl/#es-boolean
 impl ToJSValConvertible for bool {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(BooleanValue(*self));
     }
@@ -211,6 +216,7 @@ impl FromJSValConvertible for bool {
 
 // https://heycam.github.io/webidl/#es-byte
 impl ToJSValConvertible for i8 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(Int32Value(*self as i32));
     }
@@ -229,6 +235,7 @@ impl FromJSValConvertible for i8 {
 
 // https://heycam.github.io/webidl/#es-octet
 impl ToJSValConvertible for u8 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(Int32Value(*self as i32));
     }
@@ -247,6 +254,7 @@ impl FromJSValConvertible for u8 {
 
 // https://heycam.github.io/webidl/#es-short
 impl ToJSValConvertible for i16 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(Int32Value(*self as i32));
     }
@@ -265,6 +273,7 @@ impl FromJSValConvertible for i16 {
 
 // https://heycam.github.io/webidl/#es-unsigned-short
 impl ToJSValConvertible for u16 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(Int32Value(*self as i32));
     }
@@ -283,6 +292,7 @@ impl FromJSValConvertible for u16 {
 
 // https://heycam.github.io/webidl/#es-long
 impl ToJSValConvertible for i32 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(Int32Value(*self));
     }
@@ -301,6 +311,7 @@ impl FromJSValConvertible for i32 {
 
 // https://heycam.github.io/webidl/#es-unsigned-long
 impl ToJSValConvertible for u32 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(UInt32Value(*self));
     }
@@ -319,6 +330,7 @@ impl FromJSValConvertible for u32 {
 
 // https://heycam.github.io/webidl/#es-long-long
 impl ToJSValConvertible for i64 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(RUST_JS_NumberValue(*self as f64));
     }
@@ -337,6 +349,7 @@ impl FromJSValConvertible for i64 {
 
 // https://heycam.github.io/webidl/#es-unsigned-long-long
 impl ToJSValConvertible for u64 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(RUST_JS_NumberValue(*self as f64));
     }
@@ -355,6 +368,7 @@ impl FromJSValConvertible for u64 {
 
 // https://heycam.github.io/webidl/#es-float
 impl ToJSValConvertible for f32 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(RUST_JS_NumberValue(*self as f64));
     }
@@ -371,6 +385,7 @@ impl FromJSValConvertible for f32 {
 
 // https://heycam.github.io/webidl/#es-double
 impl ToJSValConvertible for f64 {
+    #[inline]
     unsafe fn to_jsval(&self, _cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(RUST_JS_NumberValue(*self));
     }
@@ -399,6 +414,7 @@ pub unsafe fn latin1_to_string(cx: *mut JSContext, s: *mut JSString) -> String {
 
 // https://heycam.github.io/webidl/#es-USVString
 impl ToJSValConvertible for str {
+    #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         let mut string_utf16: Vec<u16> = Vec::with_capacity(self.len());
         string_utf16.extend(self.encode_utf16());
@@ -414,6 +430,7 @@ impl ToJSValConvertible for str {
 
 // https://heycam.github.io/webidl/#es-USVString
 impl ToJSValConvertible for String {
+    #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         (**self).to_jsval(cx, rval);
     }
@@ -441,6 +458,7 @@ impl FromJSValConvertible for String {
 }
 
 impl<T: ToJSValConvertible> ToJSValConvertible for Option<T> {
+    #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         match self {
             &Some(ref value) => value.to_jsval(cx, rval),
@@ -450,6 +468,7 @@ impl<T: ToJSValConvertible> ToJSValConvertible for Option<T> {
 }
 
 impl<T: ToJSValConvertible> ToJSValConvertible for Rc<T> {
+    #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         (**self).to_jsval(cx, rval)
     }
@@ -472,6 +491,7 @@ impl<T: FromJSValConvertible> FromJSValConvertible for Option<T> {
 
 // https://heycam.github.io/webidl/#es-sequence
 impl<T: ToJSValConvertible> ToJSValConvertible for Vec<T> {
+    #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         rooted!(in(cx) let js_array = JS_NewArrayObject1(cx, self.len() as libc::size_t));
         assert!(!js_array.handle().is_null());
@@ -556,6 +576,7 @@ impl<C: Clone, T: FromJSValConvertible<Config=C>> FromJSValConvertible for Vec<T
 
 // https://heycam.github.io/webidl/#es-object
 impl ToJSValConvertible for *mut JSObject {
+    #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(ObjectOrNullValue(*self));
         assert!(JS_WrapValue(cx, rval));

--- a/src/jsval.rs
+++ b/src/jsval.rs
@@ -71,6 +71,7 @@ enum ValueShiftedTag {
 #[cfg(target_pointer_width = "64")]
 const JSVAL_PAYLOAD_MASK: u64 = 0x00007FFFFFFFFFFF;
 
+#[inline(always)]
 fn AsJSVal(val: u64) -> JSVal {
     JSVal {
         data: jsval_layout {

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -593,6 +593,7 @@ impl Drop for JSAutoCompartment {
 }
 
 impl JSJitMethodCallArgs {
+    #[inline]
     pub fn get(&self, i: u32) -> HandleValue {
         unsafe {
             if i < self._base.argc_ {
@@ -603,6 +604,7 @@ impl JSJitMethodCallArgs {
         }
     }
 
+    #[inline]
     pub fn index(&self, i: u32) -> HandleValue {
         assert!(i < self._base.argc_);
         unsafe {
@@ -610,6 +612,7 @@ impl JSJitMethodCallArgs {
         }
     }
 
+    #[inline]
     pub fn index_mut(&self, i: u32) -> MutableHandleValue {
         assert!(i < self._base.argc_);
         unsafe {
@@ -617,6 +620,7 @@ impl JSJitMethodCallArgs {
         }
     }
 
+    #[inline]
     pub fn rval(&self) -> MutableHandleValue {
         unsafe {
             MutableHandleValue::from_marked_location(self._base._base.argv_.offset(-2))
@@ -627,10 +631,12 @@ impl JSJitMethodCallArgs {
 // XXX need to hack up bindgen to convert this better so we don't have
 //     to duplicate so much code here
 impl CallArgs {
+    #[inline]
     pub unsafe fn from_vp(vp: *mut Value, argc: u32) -> CallArgs {
         CreateCallArgsFromVp(argc, vp)
     }
 
+    #[inline]
     pub fn index(&self, i: u32) -> HandleValue {
         assert!(i < self._base.argc_);
         unsafe {
@@ -638,6 +644,7 @@ impl CallArgs {
         }
     }
 
+    #[inline]
     pub fn index_mut(&self, i: u32) -> MutableHandleValue {
         assert!(i < self._base.argc_);
         unsafe {
@@ -645,6 +652,7 @@ impl CallArgs {
         }
     }
 
+    #[inline]
     pub fn get(&self, i: u32) -> HandleValue {
         unsafe {
             if i < self._base.argc_ {
@@ -655,12 +663,14 @@ impl CallArgs {
         }
     }
 
+    #[inline]
     pub fn rval(&self) -> MutableHandleValue {
         unsafe {
             MutableHandleValue::from_marked_location(self._base._base.argv_.offset(-2))
         }
     }
 
+    #[inline]
     pub fn thisv(&self) -> HandleValue {
         unsafe {
             HandleValue::from_marked_location(self._base._base.argv_.offset(-1))
@@ -669,12 +679,14 @@ impl CallArgs {
 }
 
 impl JSJitGetterCallArgs {
+    #[inline]
     pub fn rval(&self) -> MutableHandleValue {
         self._base
     }
 }
 
 impl JSJitSetterCallArgs {
+    #[inline]
     pub fn get(&self, i: u32) -> HandleValue {
         assert!(i == 0);
         self._base.handle()


### PR DESCRIPTION
Make it possible for Rust methods which are called in the generated bindings to be inlined. This shaved off 1/3-1/2 of the total time in the measurements in https://github.com/servo/servo/issues/12354.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/276)
<!-- Reviewable:end -->
