### PR TITLE
Return a ConversionResult::Failure when converting a non-iterable value to Vec.

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -585,8 +585,12 @@ impl<C: Clone, T: FromJSValConvertible<Config=C>> FromJSValConvertible for Vec<T
         let mut iterator = ForOfIteratorGuard::new(cx, &mut iterator);
         let iterator = &mut *iterator.root;
 
-        if !iterator.init(value, ForOfIterator_NonIterableBehavior::ThrowOnNonIterable) {
+        if !iterator.init(value, ForOfIterator_NonIterableBehavior::AllowNonIterable) {
             return Err(())
+        }
+
+        if iterator.iterator.ptr.is_null() {
+            return Ok(ConversionResult::Failure("Value is not iterable".into()));
         }
 
         let mut ret = vec![];

--- a/tests/vec_conversion.rs
+++ b/tests/vec_conversion.rs
@@ -6,6 +6,7 @@
 extern crate js;
 
 use js::conversions::ConversionBehavior;
+use js::conversions::ConversionResult;
 use js::conversions::FromJSValConvertible;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::CompartmentOptions;
@@ -57,5 +58,13 @@ fn vec_conversion() {
                                  ConversionBehavior::Default).unwrap();
 
         assert_eq!(&orig_vec, converted.get_success_value().unwrap());
+
+        rt.evaluate_script(global, "({})", "test", 1, rval.handle_mut()).unwrap();
+        let converted = Vec::<i32>::from_jsval(cx, rval.handle(),
+                                               ConversionBehavior::Default);
+        assert!(match converted {
+            Ok(ConversionResult::Failure(_)) => true,
+            _ => false,
+        });
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/306)
<!-- Reviewable:end -->
