### PR TITLE
Wrap uses of extern statics in unsafe blocks.

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -440,11 +440,15 @@ impl<T> DerefMut for MutableHandle<T> {
 
 impl HandleValue {
     pub fn null() -> HandleValue {
-        NullHandleValue
+        unsafe {
+            NullHandleValue
+        }
     }
 
     pub fn undefined() -> HandleValue {
-        UndefinedHandleValue
+        unsafe {
+            UndefinedHandleValue
+        }
     }
 }
 
@@ -459,7 +463,11 @@ impl HandleObject {
 }
 
 impl Default for jsid {
-    fn default() -> jsid { JSID_VOID }
+    fn default() -> jsid {
+        unsafe {
+            JSID_VOID
+        }
+    }
 }
 
 impl Default for Value {


### PR DESCRIPTION
This fixes safe_extern_statics warnings; see
<https://github.com/rust-lang/rust/issues/36247>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/307)
<!-- Reviewable:end -->
