### PR TITLE
Implement a Trace trait for types that can be traced.

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -564,6 +564,14 @@ impl<T: GCMethods<T> + Copy> Heap<T> {
     }
 }
 
+impl<T: GCMethods<T> + Copy> Clone for Heap<T>
+    where Heap<T>: Default
+{
+    fn clone(&self) -> Self {
+        Heap::new(self.get())
+    }
+}
+
 impl<T> Default for Heap<*mut T>
     where *mut T: GCMethods<*mut T> + Copy
 {

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -556,8 +556,10 @@ impl<T: GCMethods<T> + Copy> Heap<T> {
     }
 }
 
-impl Default for Heap<*mut JSObject> {
-    fn default() -> Heap<*mut JSObject> {
+impl<T> Default for Heap<*mut T>
+    where *mut T: GCMethods<*mut T> + Copy
+{
+    fn default() -> Heap<*mut T> {
         Heap {
             ptr: UnsafeCell::new(ptr::null_mut())
         }

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -599,6 +599,11 @@ impl<T: GCMethods<T> + Copy> Drop for Heap<T> {
     }
 }
 
+impl<T: GCMethods<T> + Copy + PartialEq> PartialEq for Heap<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.get() == other.get()
+    }
+}
 
 // ___________________________________________________________________________
 // Implementations for various things in jsapi.rs

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -532,6 +532,14 @@ impl GCMethods<Value> for Value {
 }
 
 impl<T: GCMethods<T> + Copy> Heap<T> {
+    pub fn new(v: T) -> Heap<T>
+        where Heap<T>: Default
+    {
+        let mut ptr = Heap::default();
+        ptr.set(v);
+        ptr
+    }
+
     pub fn set(&mut self, v: T) {
         unsafe {
             let ptr = self.ptr.get();


### PR DESCRIPTION
We expose several JSAPI functions that are used for tracing. By abstracting these functions behind
a trait we can overload them on the type to be traced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/314)
<!-- Reviewable:end -->
