### PR TITLE
Use a less strict bound for wrap_panic.

### DIFF
--- a/src/panic.rs
+++ b/src/panic.rs
@@ -17,7 +17,7 @@ pub fn maybe_resume_unwind() {
 
 /// Generic wrapper for JS engine callbacks panic-catching
 pub fn wrap_panic<F, R>(function: F, generic_return_type: R) -> R
-    where F: FnMut() -> R + UnwindSafe
+    where F: FnOnce() -> R + UnwindSafe
 {
     let result = catch_unwind(function);
     match result {


### PR DESCRIPTION
This is what's required for catch_unwind; there's no need to be stricter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/317)
<!-- Reviewable:end -->
