### PR TITLE
Add methods to create a HandleValueArray.

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -20,8 +20,8 @@ use consts::{JSCLASS_RESERVED_SLOTS_MASK, JSCLASS_GLOBAL_SLOT_COUNT};
 use consts::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
 use jsapi;
 use jsapi::{AutoIdVector, AutoObjectVector, CallArgs, CompartmentOptions, ContextFriendFields};
-use jsapi::{Evaluate2, Handle, HandleBase, HandleObject, HandleValue, Heap, HeapObjectPostBarrier};
-use jsapi::{HeapValuePostBarrier, InitSelfHostedCode, IsWindowSlow, JS_BeginRequest};
+use jsapi::{Evaluate2, Handle, HandleBase, HandleObject, HandleValue, HandleValueArray, Heap};
+use jsapi::{HeapObjectPostBarrier, HeapValuePostBarrier, InitSelfHostedCode, IsWindowSlow, JS_BeginRequest};
 use jsapi::{JS_DefineFunctions, JS_DefineProperties, JS_DestroyRuntime, JS_EndRequest};
 use jsapi::{JS_EnterCompartment, JS_EnumerateStandardClasses, JS_GetContext, JS_GlobalObjectTraceHook};
 use jsapi::{JS_Init, JS_LeaveCompartment, JS_MayResolveStandardClass, JS_NewRuntime, JS_ResolveStandardClass};
@@ -491,6 +491,22 @@ impl HandleValue {
     pub fn undefined() -> HandleValue {
         unsafe {
             UndefinedHandleValue
+        }
+    }
+}
+
+impl HandleValueArray {
+    pub fn new() -> HandleValueArray {
+        HandleValueArray {
+            length_: 0,
+            elements_: ptr::null(),
+        }
+    }
+
+    pub unsafe fn from_rooted_slice(values: &[Value]) -> HandleValueArray {
+        HandleValueArray {
+            length_: values.len(),
+            elements_: values.as_ptr()
         }
     }
 }


### PR DESCRIPTION
Rust-mozjs currently does not define any methods to create instances of HandleValueArray.
Consequently, consumers have to create these instances manually. This is unnecessary boilerplate,
and therefore should be abstracted behind a function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/319)
<!-- Reviewable:end -->
