### PR TITLE
Implement `AsHandle` and `AsHandleMut` traits.

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -42,6 +42,7 @@ use rust::{ToString, maybe_wrap_object_or_null_value};
 use rust::{maybe_wrap_object_value, maybe_wrap_value};
 use libc;
 use num_traits::{Bounded, Zero};
+use rust::{AsHandle, AsHandleMut};
 use std::borrow::Cow;
 use std::rc::Rc;
 use std::{ptr, slice};

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -20,8 +20,8 @@ use consts::{JSCLASS_RESERVED_SLOTS_MASK, JSCLASS_GLOBAL_SLOT_COUNT};
 use consts::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
 use jsapi;
 use jsapi::{AutoIdVector, AutoObjectVector, CallArgs, CompartmentOptions, ContextFriendFields};
-use jsapi::{Evaluate2, Handle, HandleBase, HandleObject, HandleValue, Heap, HeapObjectPostBarrier};
-use jsapi::{HeapValuePostBarrier, InitSelfHostedCode, IsWindowSlow, JS_BeginRequest};
+use jsapi::{Evaluate2, Handle, HandleBase, HandleObject, HandleValue, HandleValueArray, Heap};
+use jsapi::{HeapObjectPostBarrier, HeapValuePostBarrier, InitSelfHostedCode, IsWindowSlow, JS_BeginRequest};
 use jsapi::{JS_DefineFunctions, JS_DefineProperties, JS_DestroyRuntime, JS_EndRequest};
 use jsapi::{JS_EnterCompartment, JS_EnumerateStandardClasses, JS_GetContext, JS_GlobalObjectTraceHook};
 use jsapi::{JS_Init, JS_LeaveCompartment, JS_MayResolveStandardClass, JS_NewRuntime, JS_ResolveStandardClass};
@@ -491,6 +491,22 @@ impl HandleValue {
     pub fn undefined() -> HandleValue {
         unsafe {
             UndefinedHandleValue
+        }
+    }
+}
+
+impl HandleValueArray {
+    pub fn new() -> HandleValueArray {
+        HandleValueArray {
+            length_: 0,
+            elements_: ptr::null(),
+        }
+    }
+
+    pub unsafe fn from_rooted_slice(values: &[Value]) -> HandleValueArray {
+        HandleValueArray {
+            length_: values.len(),
+            elements_: values.as_ptr()
         }
     }
 }

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -17,7 +17,7 @@ use js::jsapi::JS_ReportError;
 use js::jsapi::OnNewGlobalHookOption;
 use js::jsapi::Value;
 use js::jsval::UndefinedValue;
-use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
+use js::rust::{AsHandle, AsHandleMut, Runtime, SIMPLE_GLOBAL_CLASS};
 
 use std::ffi::CStr;
 use std::ptr;

--- a/tests/enumerate.rs
+++ b/tests/enumerate.rs
@@ -14,6 +14,8 @@ use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::JS_StringEqualsAscii;
 use js::jsapi::OnNewGlobalHookOption;
 use js::jsval::UndefinedValue;
+use js::rust::AsHandle;
+use js::rust::AsHandleMut;
 use js::rust::IdVector;
 use js::rust::Runtime;
 use js::rust::SIMPLE_GLOBAL_CLASS;

--- a/tests/evaluate.rs
+++ b/tests/evaluate.rs
@@ -9,7 +9,7 @@ use js::jsapi::CompartmentOptions;
 use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::OnNewGlobalHookOption;
 use js::jsval::UndefinedValue;
-use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
+use js::rust::{AsHandle, AsHandleMut, Runtime, SIMPLE_GLOBAL_CLASS};
 
 use std::ptr;
 

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -14,7 +14,7 @@ use js::jsapi::OnNewGlobalHookOption;
 use js::jsapi::Value;
 use js::jsval::UndefinedValue;
 use js::panic::wrap_panic;
-use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
+use js::rust::{AsHandle, AsHandleMut, Runtime, SIMPLE_GLOBAL_CLASS};
 use std::ptr;
 use std::str;
 

--- a/tests/stack_limit.rs
+++ b/tests/stack_limit.rs
@@ -9,7 +9,7 @@ use js::jsapi::CompartmentOptions;
 use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::OnNewGlobalHookOption;
 use js::jsval::UndefinedValue;
-use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
+use js::rust::{AsHandle, AsHandleMut, Runtime, SIMPLE_GLOBAL_CLASS};
 
 use std::ptr;
 

--- a/tests/typedarray.rs
+++ b/tests/typedarray.rs
@@ -10,6 +10,8 @@ use js::jsapi::JSAutoCompartment;
 use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::OnNewGlobalHookOption;
 use js::jsval::UndefinedValue;
+use js::rust::AsHandle;
+use js::rust::AsHandleMut;
 use js::rust::Runtime as Runtime_;
 use js::rust::SIMPLE_GLOBAL_CLASS;
 use js::typedarray::Uint32Array;

--- a/tests/vec_conversion.rs
+++ b/tests/vec_conversion.rs
@@ -15,7 +15,7 @@ use js::jsapi::JS_InitStandardClasses;
 use js::jsapi::JS_NewGlobalObject;
 use js::jsapi::OnNewGlobalHookOption;
 use js::jsval::UndefinedValue;
-use js::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
+use js::rust::{AsHandle, AsHandleMut, Runtime, SIMPLE_GLOBAL_CLASS};
 
 use std::ptr;
 


### PR DESCRIPTION
Several types in rust-mozjs, such as Heap, PersistentRooted, and RootedGuard, represent a rooted
    value. A common property of rooted values is that a handle can be obtained to it. Rather than
    implement this property separately for each of these types, we should abstract it out into these
    two traits.
    
    This has several advantages: for instance, one can write functions that take any rooted value as
    argument, regardless of how it is implemented, and then obtain a handle to it. Additionally, it
    allows one to implement these traits for newtypes which underlying type is a rooted value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/320)
<!-- Reviewable:end -->
