### PR TITLE
Allow interior mutability of Heap objects.

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -628,12 +628,12 @@ impl<T: GCMethods + Copy> Heap<T> {
     pub fn new(v: T) -> Heap<T>
         where Heap<T>: Default
     {
-        let mut ptr = Heap::default();
+        let ptr = Heap::default();
         ptr.set(v);
         ptr
     }
 
-    pub fn set(&mut self, v: T) {
+    pub fn set(&self, v: T) {
         unsafe {
             let ptr = self.ptr.get();
             let prev = *ptr;


### PR DESCRIPTION
Over in https://github.com/servo/servo/pull/15120, there's an implementation of `WindowProxy` to `Window` bindings, which updates the `WindowProxy` when navigation happens. This requires mutating the reflector, which is a lot easier if `Heap` implements interior mutability. `Heap` already has an `UnsafeCell` internally, so the only change is that `Heap::set` takes a `&self` rather than a `&mut self`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/328)
<!-- Reviewable:end -->
