### PR TITLE
Call JS_ShutDown when all runtimes have been dropped.

### DIFF
--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -25,7 +25,7 @@ use std::str;
 
 #[test]
 fn callback() {
-    let runtime = Runtime::new();
+    let runtime = Runtime::new().unwrap();
     let context = runtime.cx();
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = CompartmentOptions::default();

--- a/tests/enumerate.rs
+++ b/tests/enumerate.rs
@@ -21,7 +21,7 @@ use std::ptr;
 
 #[test]
 fn enumerate() {
-    let rt = Runtime::new();
+    let rt = Runtime::new().unwrap();
     let cx = rt.cx();
 
     unsafe {

--- a/tests/evaluate.rs
+++ b/tests/evaluate.rs
@@ -15,7 +15,7 @@ use std::ptr;
 
 #[test]
 fn evaluate() {
-    let rt = Runtime::new();
+    let rt = Runtime::new().unwrap();
     let cx = rt.cx();
 
     unsafe {

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -21,7 +21,7 @@ use std::str;
 #[test]
 #[should_panic]
 fn panic() {
-    let runtime = Runtime::new();
+    let runtime = Runtime::new().unwrap();
     let context = runtime.cx();
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = CompartmentOptions::default();

--- a/tests/rooting.rs
+++ b/tests/rooting.rs
@@ -28,7 +28,7 @@ use std::ptr;
 #[test]
 fn rooting() {
     unsafe {
-        let runtime = Runtime::new();
+        let runtime = Runtime::new().unwrap();
         JS_SetGCZeal(runtime.rt(), 2, 1);
 
         let cx = runtime.cx();

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -21,7 +21,7 @@ use std::ptr;
 #[test]
 fn runtime() {
     unsafe {
-        let runtime = Runtime::new();
+        let runtime = Runtime::new().unwrap();
 
         let cx = runtime.cx();
         let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
@@ -35,6 +35,8 @@ fn runtime() {
         let _ac = JSAutoCompartment::new(cx, global.get());
         rooted!(in(cx) let _object = JS_NewObject(cx, &CLASS as *const _));
     }
+
+    assert!(Runtime::new().is_err());
 }
 
 unsafe extern fn finalize(_fop: *mut JSFreeOp, _object: *mut JSObject) {

--- a/tests/stack_limit.rs
+++ b/tests/stack_limit.rs
@@ -15,7 +15,7 @@ use std::ptr;
 
 #[test]
 fn stack_limit() {
-    let rt = Runtime::new();
+    let rt = Runtime::new().unwrap();
     let cx = rt.cx();
 
     unsafe {

--- a/tests/typedarray.rs
+++ b/tests/typedarray.rs
@@ -18,7 +18,7 @@ use std::ptr;
 
 #[test]
 fn typedarray() {
-    let rt = Runtime_::new();
+    let rt = Runtime_::new().unwrap();
     let cx = rt.cx();
 
     unsafe {
@@ -76,7 +76,7 @@ fn typedarray() {
 #[test]
 #[should_panic]
 fn typedarray_update_panic() {
-    let rt = Runtime_::new();
+    let rt = Runtime_::new().unwrap();
     let cx = rt.cx();
 
     unsafe {

--- a/tests/vec_conversion.rs
+++ b/tests/vec_conversion.rs
@@ -21,7 +21,7 @@ use std::ptr;
 
 #[test]
 fn vec_conversion() {
-    let rt = Runtime::new();
+    let rt = Runtime::new().unwrap();
     let cx = rt.cx();
 
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;


### PR DESCRIPTION
This will enable better investigation of Servo's shutdown behaviour, since currently all of the JS helper threads just sit there until process exit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/344)
<!-- Reviewable:end -->
