### PR TITLE
Rewrote documentation for conversion failure modes.

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -100,7 +100,7 @@ pub trait ToJSValConvertible {
 pub enum ConversionResult<T> {
     /// Everything went fine.
     Success(T),
-    /// Pending exception.
+    /// Conversion failed, without a pending exception.
     Failure(Cow<'static, str>),
 }
 
@@ -122,6 +122,7 @@ pub trait FromJSValConvertible: Sized {
     /// Optional configuration of type `T` can be passed as the `option`
     /// argument.
     /// If it returns `Err(())`, a JSAPI exception is pending.
+    /// If it returns `Ok(Failure(reason))`, there is no pending JSAPI exception.
     unsafe fn from_jsval(cx: *mut JSContext,
                          val: HandleValue,
                          option: Self::Config)


### PR DESCRIPTION
Improved the documentation about when `from_jsval` is expected to produce a pending JSAPI exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/364)
<!-- Reviewable:end -->
