### PR TITLE
Remove unused `link_args` feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 #![crate_name = "js"]
 #![crate_type = "rlib"]
 
-#![feature(link_args)]
 #![feature(nonzero)]
 #![feature(const_fn)]
 


### PR DESCRIPTION
We now print `cargo:rustc-link-…` from `build.rs` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/370)
<!-- Reviewable:end -->
