### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/etc/bindings-all.py
+++ b/etc/bindings-all.py
@@ -11,6 +11,7 @@ def usage_and_exit():
     print("    tests them.")
     print("")
     print("    <platform>         One of 'linux_32', 'linux_64', 'macos_64',")
+    print("                       'freebsd_32', 'freebsd_64',")
     print("                       'windows_gcc_64', or 'windows_msvc14_64'.")
     print("")
     print("    <bindgen>          The path to bindgen")
@@ -26,7 +27,7 @@ if len(sys.argv) != 4:
 [platform, bindgen, clang_lib_path] = sys.argv[1:]
 
 try:
-    ["linux_32", "linux_64", "macos_64", "windows_gcc_64", "windows_msvc14_64"].index(platform)
+    ["linux_32", "linux_64", "freebsd_32", "freebsd_64", "macos_64", "windows_gcc_64", "windows_msvc14_64"].index(platform)
 except ValueError:
     print("error: {} is not a valid platform".format(platform))
     usage_and_exit()

--- a/src/jsglue.cpp
+++ b/src/jsglue.cpp
@@ -778,6 +778,8 @@ DeleteAutoObjectVector(JS::AutoObjectVector* v)
  #include <malloc.h>
 #elif defined(__APPLE__)
  #include <malloc/malloc.h>
+#elif defined(__FreeBSD__)
+ #include <malloc_np.h>
 #elif defined(__MINGW32__) || defined(__MINGW64__)
  // nothing needed here
 #elif defined(_MSC_VER)
@@ -789,7 +791,7 @@ DeleteAutoObjectVector(JS::AutoObjectVector* v)
 // SpiderMonkey-in-Rust currently uses system malloc, not jemalloc.
 static size_t MallocSizeOf(const void* aPtr)
 {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
     return malloc_usable_size((void*)aPtr);
 #elif defined(__APPLE__)
     return malloc_size((void*)aPtr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,12 +38,12 @@ pub mod jsapi {
     #[cfg(target_env = "msvc")]
     pub type char16_t = ::std::os::raw::c_ushort;
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     #[cfg(target_pointer_width = "64")]
     #[cfg(not(feature = "debugmozjs"))]
     include!("jsapi_linux_64.rs");
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     #[cfg(target_pointer_width = "64")]
     #[cfg(feature = "debugmozjs")]
     include!("jsapi_linux_64_debug.rs");
@@ -82,12 +82,12 @@ pub mod jsapi {
     #[cfg(feature = "debugmozjs")]
     include!("jsapi_windows_msvc14_64_debug.rs");
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     #[cfg(target_pointer_width = "32")]
     #[cfg(not(feature = "debugmozjs"))]
     include!("jsapi_linux_32.rs");
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     #[cfg(target_pointer_width = "32")]
     #[cfg(feature = "debugmozjs")]
     include!("jsapi_linux_32_debug.rs");


### PR DESCRIPTION
The generated bindings for Linux seem to work fine o_0

Tried building the last revision of bindgen before the rewrite that removed `match`, but it crashes with `SIGILL` when generating the bindings…

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/372)
<!-- Reviewable:end -->
