### PR TITLE
Remove `heapsize` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "js"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"
@@ -41,5 +41,4 @@ git = "https://github.com/servo/mozjs"
 lazy_static = "0.2.1"
 libc = "0.2"
 log = "0.3"
-heapsize = ">=0.2, <0.5"
 num-traits = "0.1.32"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case, improper_ctypes)]
 
 #[macro_use]
-extern crate heapsize;
-#[macro_use]
 extern crate lazy_static;
 extern crate libc;
 #[macro_use]
@@ -103,7 +101,6 @@ pub mod typedarray;
 
 pub use consts::*;
 
-use heapsize::HeapSizeOf;
 use jsapi::{JSContext, Heap};
 use jsval::JSVal;
 use rust::GCMethods;
@@ -117,14 +114,6 @@ pub unsafe fn JS_ARGV(_cx: *mut JSContext, vp: *mut JSVal) -> *mut JSVal {
 pub unsafe fn JS_CALLEE(_cx: *mut JSContext, vp: *mut JSVal) -> JSVal {
     *vp
 }
-
-// This is measured properly by the heap measurement implemented in SpiderMonkey.
-impl<T: Copy + GCMethods> HeapSizeOf for Heap<T> {
-    fn heap_size_of_children(&self) -> usize {
-        0
-    }
-}
-known_heap_size!(0, JSVal);
 
 impl jsapi::ObjectOpResult {
     /// Set this ObjectOpResult to true and return true.

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -5,7 +5,6 @@
 //! Rust wrappers around the raw JS apis
 
 use libc::{size_t, c_uint, c_char};
-use heapsize::HeapSizeOf;
 use std::char;
 use std::ffi;
 use std::ptr;
@@ -249,13 +248,6 @@ impl Drop for Runtime {
                 JS_ShutDown();
             }
         }
-    }
-}
-
-// This is measured through `glue::CollectServoSizes`.
-impl HeapSizeOf for Runtime {
-    fn heap_size_of_children(&self) -> usize {
-        0
     }
 }
 


### PR DESCRIPTION
The `heapsize` crate is being deprecated in favour of the
`malloc_size_of` crate within Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/375)
<!-- Reviewable:end -->
