### PR TITLE
Don't rerun build script unnecessarily

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,4 +8,5 @@ fn main() {
     let dst = cmake::Config::new(".").build();
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=jsglue");
+    println!("cargo:rerun-if-changed=src/jsglue.cpp");
 }


### PR DESCRIPTION
Closes #380. From what I can see the only thing [impacting](https://github.com/servo/rust-mozjs/blob/master/CMakeLists.txt#L7) the cmake build is the jsglue.cpp file, so I set to only watch that file, instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/383)
<!-- Reviewable:end -->
