### PR TITLE
Prune some compiler warnings

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -39,7 +39,7 @@ use jsval::{BooleanValue, Int32Value, NullValue, UInt32Value, UndefinedValue};
 use jsval::{JSVal, ObjectValue, ObjectOrNullValue, StringValue};
 use rust::{ToBoolean, ToInt32, ToInt64, ToNumber, ToUint16, ToUint32, ToUint64};
 use rust::{ToString, maybe_wrap_object_or_null_value};
-use rust::{maybe_wrap_object_value, maybe_wrap_value};
+use rust::maybe_wrap_value;
 use libc;
 use num_traits::{Bounded, Zero};
 use std::borrow::Cow;
@@ -612,7 +612,7 @@ impl<C: Clone, T: FromJSValConvertible<Config=C>> FromJSValConvertible for Vec<T
             iterator: RootedObject::new_unrooted(),
             index: ::std::u32::MAX, // NOT_ARRAY
         };
-        let mut iterator = ForOfIteratorGuard::new(cx, &mut iterator);
+        let iterator = ForOfIteratorGuard::new(cx, &mut iterator);
         let iterator = &mut *iterator.root;
 
         if !iterator.init(value, ForOfIterator_NonIterableBehavior::AllowNonIterable) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,8 @@ pub mod typedarray;
 
 pub use consts::*;
 
-use jsapi::{JSContext, Heap};
+use jsapi::JSContext;
 use jsval::JSVal;
-use rust::GCMethods;
 
 #[inline(always)]
 pub unsafe fn JS_ARGV(_cx: *mut JSContext, vp: *mut JSVal) -> *mut JSVal {

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -16,7 +16,6 @@ use mozjs::jsval::UndefinedValue;
 use mozjs::panic::wrap_panic;
 use mozjs::rust::{Runtime, SIMPLE_GLOBAL_CLASS};
 use std::ptr;
-use std::str;
 
 #[test]
 #[should_panic]


### PR DESCRIPTION
There were a couple of warnings issued by rustc, mostly unused imports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/384)
<!-- Reviewable:end -->
