### PR TITLE
Remove FromJSValConvertible implementation for HandleValue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -654,3 +654,22 @@ impl ToJSValConvertible for Heap<*mut JSObject> {
         maybe_wrap_object_or_null_value(cx, rval);
     }
 }
+
+// https://heycam.github.io/webidl/#es-object
+impl FromJSValConvertible for *mut JSObject {
+    type Config = ();
+    #[inline]
+    unsafe fn from_jsval(cx: *mut JSContext,
+                         value: HandleValue,
+                         _option: ())
+                         -> Result<ConversionResult<*mut JSObject>, ()> {
+        if !value.is_object() {
+            throw_type_error(cx, "value is not an object");
+            return Err(());
+        }
+
+        AssertSameCompartment(cx, value.to_object());
+
+        Ok(ConversionResult::Success(value.to_object()))
+    }
+}

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -185,20 +185,6 @@ impl ToJSValConvertible for () {
     }
 }
 
-impl FromJSValConvertible for HandleValue {
-    type Config = ();
-    #[inline]
-    unsafe fn from_jsval(cx: *mut JSContext,
-                         value: HandleValue,
-                         _option: ())
-                         -> Result<ConversionResult<HandleValue>, ()> {
-        if value.is_object() {
-            AssertSameCompartment(cx, value.to_object());
-        }
-        Ok(ConversionResult::Success(value))
-    }
-}
-
 impl FromJSValConvertible for JSVal {
     type Config = ();
     unsafe fn from_jsval(_cx: *mut JSContext,

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -593,7 +593,7 @@ impl<T: CustomTrace> CustomAutoRooter<T> {
 /// The underlying data can be accessed through this guard via its Deref and
 /// DerefMut implementations.
 /// This structure is created by `root` method on `CustomAutoRooter` or
-/// by an appropriate macro (e.g. `rooted_vec!` for `SequenceRooter` alias).
+/// by the `auto_root!` macro.
 pub struct CustomAutoRooterGuard<'a, T: 'a + CustomTrace> {
     rooter: &'a mut CustomAutoRooter<T>
 }


### PR DESCRIPTION
Needed for https://github.com/servo/servo/pull/19644.

Removes FromJSValConvertible implementations for `HandleValue`, so `Vec<HandleValue>` conversion is impossible.
Also adds the implementation for `*mut JSObject` so the `sequence<object>` -> `CustomAutoRooterGuard<Vec<*mut JSObject>>` conversion works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/388)
<!-- Reviewable:end -->
