### PR TITLE
Add a conversion from the newly-#[stable] `ptr::NonNull` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -38,7 +38,7 @@ use jsapi::{JSContext, JSObject, JSString, MutableHandleValue, RootedObject};
 use jsval::{BooleanValue, Int32Value, NullValue, UInt32Value, UndefinedValue};
 use jsval::{JSVal, ObjectValue, ObjectOrNullValue, StringValue};
 use rust::{ToBoolean, ToInt32, ToInt64, ToNumber, ToUint16, ToUint32, ToUint64};
-use rust::{ToString, maybe_wrap_object_or_null_value};
+use rust::{ToString, maybe_wrap_object_or_null_value, maybe_wrap_object_value};
 use rust::maybe_wrap_value;
 use libc;
 use num_traits::{Bounded, Zero};
@@ -643,6 +643,15 @@ impl ToJSValConvertible for *mut JSObject {
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(ObjectOrNullValue(*self));
         maybe_wrap_object_or_null_value(cx, rval);
+    }
+}
+
+// https://heycam.github.io/webidl/#es-object
+impl ToJSValConvertible for ptr::NonNull<JSObject> {
+    #[inline]
+    unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
+        rval.set(ObjectValue(self.as_ptr()));
+        maybe_wrap_object_value(cx, rval);
     }
 }
 


### PR DESCRIPTION
This will allow removing the `NonNullJSObjectPtr` hack in Servo, but raises the minimum Rust version to 1.25 (currently Nigthly)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/390)
<!-- Reviewable:end -->
