### PR TITLE
Add safe Heap::boxed constructor

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -836,6 +836,21 @@ impl<T: GCMethods + Copy> Heap<T> {
         ptr
     }
 
+    /// This creates a `Box`-wrapped Heap value. Setting a value inside Heap
+    /// object triggers a barrier, referring to the Heap object location,
+    /// hence why it is not safe to construct a temporary Heap value, assign
+    /// a non-null value and move it (e.g. typical object construction).
+    ///
+    /// Using boxed Heap value guarantees that the underlying Heap value will
+    /// not be moved when constructed.
+    pub fn boxed(v: T) -> Box<Heap<T>>
+        where Heap<T>: Default
+    {
+        let boxed = Box::new(Heap::default());
+        boxed.set(v);
+        boxed
+    }
+
     pub fn set(&self, v: T) {
         unsafe {
             let ptr = self.ptr.get();


### PR DESCRIPTION
While this doesn't remove old Heap constructor (#343), it adds a new `boxed` function along with some additional explanation while this may be preferred until a better/different solution comes up to construct a Heap value directly with an appropriate value set, in a safe manner.

This made my work (which I'll upload later) on typed arrays, and also indirectly for objects, in webidl unions safer and more convenient, so I think it's a good addition.

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/395)
<!-- Reviewable:end -->
