### PR TITLE
Remove Heap::new constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -195,16 +195,6 @@ impl FromJSValConvertible for JSVal {
     }
 }
 
-impl FromJSValConvertible for Heap<JSVal> {
-    type Config = ();
-    unsafe fn from_jsval(_cx: *mut JSContext,
-                         value: HandleValue,
-                         _option: ())
-                         -> Result<ConversionResult<Self>, ()> {
-        Ok(ConversionResult::Success(Heap::new(value.get())))
-    }
-}
-
 impl ToJSValConvertible for JSVal {
     #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,20 @@ extern crate num_traits;
 pub mod jsapi {
     use libc::FILE;
 
+    /// Heap values encapsulate GC concerns of an on-heap reference to a JS
+    /// object. This means that every reference to a JS object on heap must
+    /// be realized through this structure.
+    ///
+    /// # Safety
+    /// For garbage collection to work correctly in SpiderMonkey, modifying the
+    /// wrapped value triggers a GC barrier, pointing to the underlying object.
+    ///
+    /// This means that after calling the `set()` function with a non-null or
+    /// non-undefined value, the `Heap` wrapper *must not* be moved, since doing
+    /// so will invalidate the local reference to wrapped value, still held by
+    /// SpiderMonkey.
+    ///
+    /// For safe `Heap` construction with value see `Heap::boxed` function.
     #[repr(C)]
     #[derive(Debug)]
     pub struct Heap<T: ::rust::GCMethods + Copy> {

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -828,14 +828,6 @@ impl GCMethods for Value {
 }
 
 impl<T: GCMethods + Copy> Heap<T> {
-    pub fn new(v: T) -> Heap<T>
-        where Heap<T>: Default
-    {
-        let ptr = Heap::default();
-        ptr.set(v);
-        ptr
-    }
-
     /// This creates a `Box`-wrapped Heap value. Setting a value inside Heap
     /// object triggers a barrier, referring to the Heap object location,
     /// hence why it is not safe to construct a temporary Heap value, assign
@@ -878,14 +870,6 @@ impl<T: GCMethods + Copy> Heap<T> {
         unsafe {
             MutableHandle::from_marked_location(self.ptr.get())
         }
-    }
-}
-
-impl<T: GCMethods + Copy> Clone for Heap<T>
-    where Heap<T>: Default
-{
-    fn clone(&self) -> Self {
-        Heap::new(self.get())
     }
 }
 


### PR DESCRIPTION
Closes #343.

This removes the `Heap::new` constructor and adds a bit more info/explanation how Heap works and why it's not safe to move it after setting the value.

This bumps minor version again since the API changes are breaking and I think this should not be merged until Servo PR (which I'll send later) passes tests/is good enough with these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/398)
<!-- Reviewable:end -->
