### PR TITLE
Add safe `to_vec` for TypedArray wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"

--- a/src/typedarray.rs
+++ b/src/typedarray.rs
@@ -170,6 +170,18 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
         &self.object
     }
 
+    /// Retrieves an owned data that's represented by the typed array.
+    pub fn to_vec(&mut self) -> Vec<T::Element>
+        where T::Element: Clone
+    {
+        // This is safe, because we immediately copy from the underlying buffer
+        // to an owned collection. Otherwise, one needs to be careful, since
+        // the underlying buffer can easily invalidated when transferred with
+        // postMessage to another thread (To remedy that, we shouldn't
+        // execute any JS code between getting the data pointer and using it).
+        unsafe { self.as_slice().to_vec() }
+    }
+
     /// # Unsafety
     ///
     /// The returned slice can be invalidated if the underlying typed array

--- a/tests/typedarray.rs
+++ b/tests/typedarray.rs
@@ -39,6 +39,9 @@ fn typedarray() {
         typedarray!(in(cx) let array: Uint8Array = rval.to_object());
         assert_eq!(array.unwrap().as_slice(), &[0, 2, 4][..]);
 
+        typedarray!(in(cx) let array: Uint8Array = rval.to_object());
+        assert_eq!(array.unwrap().to_vec(), vec![0, 2, 4]);
+
         typedarray!(in(cx) let array: Uint16Array = rval.to_object());
         assert!(array.is_err());
 


### PR DESCRIPTION
Also bumps the version to 0.3.2.

r? @jdm 

Included the reasoning as to why it's safe as per our discussion on IRC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/402)
<!-- Reviewable:end -->
