### PR TITLE
Sanitize Heap::handle(_mut) functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -860,10 +860,21 @@ impl<T: GCMethods + Copy> Heap<T> {
         self.ptr.get()
     }
 
-    pub fn handle(&self) -> Handle<T> {
-        unsafe {
-            Handle::from_marked_location(self.ptr.get() as *const _)
-        }
+    /// Retrieves a Handle to the underlying value.
+    ///
+    /// # Safety
+    ///
+    /// This is only safe to do on a rooted object (which Heap is not, it needs
+    /// to be additionally rooted), like RootedGuard, so use this only if you
+    /// know what you're doing.
+    ///
+    /// # Notes
+    ///
+    /// Since Heap values need to be informed when a change to underlying
+    /// value is made (e.g. via `get()`), this does not allow to create
+    /// MutableHandle objects, which can bypass this and lead to crashes.
+    pub unsafe fn handle(&self) -> Handle<T> {
+        Handle::from_marked_location(self.ptr.get() as *const _)
     }
 }
 

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -865,12 +865,6 @@ impl<T: GCMethods + Copy> Heap<T> {
             Handle::from_marked_location(self.ptr.get() as *const _)
         }
     }
-
-    pub fn handle_mut(&self) -> MutableHandle<T> {
-        unsafe {
-            MutableHandle::from_marked_location(self.ptr.get())
-        }
-    }
 }
 
 impl<T> Default for Heap<*mut T>


### PR DESCRIPTION
Fixes #351.

Also marked `Heap::handle` as `unsafe`, hopefully the explanation in the code is concise/good enough.

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/404)
<!-- Reviewable:end -->
