### PR TITLE
Added Default implementation for PropertyDescriptor

### DIFF
--- a/src/property_descriptor.rs
+++ b/src/property_descriptor.rs
@@ -1,0 +1,9 @@
+use jsapi::PropertyDescriptor
+use jsapi::UndefinedValue
+use std::ptr::null
+
+impl Default for PropertyDescriptor {
+    fn defuault() -> PropertyDescriptor {
+        PropertyDescriptor {null, 0, None, None, UndefinedValue()}
+    }
+}

--- a/src/property_descriptor.rs
+++ b/src/property_descriptor.rs
@@ -1,9 +1,0 @@
-use jsapi::PropertyDescriptor
-use jsapi::UndefinedValue
-use std::ptr::null
-
-impl Default for PropertyDescriptor {
-    fn defuault() -> PropertyDescriptor {
-        PropertyDescriptor {null, 0, None, None, UndefinedValue()}
-    }
-}

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -39,6 +39,7 @@ use jsapi::{ToUint32Slow, ToUint64Slow, ToWindowProxyIfWindow, UndefinedHandleVa
 use jsapi::{Value, jsid, PerThreadDataFriendFields, PerThreadDataFriendFields_RuntimeDummy};
 use jsapi::{CaptureCurrentStack, BuildStackString, IsSavedFrame};
 use jsapi::{AutoGCRooter_jspubtd_h_unnamed_1 as AutoGCRooterTag, _vftable_CustomAutoRooter as CustomAutoRooterVFTable};
+use jsapi::PropertyDescriptor;
 use jsval::{ObjectValue, UndefinedValue};
 use glue::{AppendToAutoObjectVector, CallFunctionTracer, CallIdTracer, CallObjectTracer};
 use glue::{CallScriptTracer, CallStringTracer, CallValueTracer, CreateAutoIdVector};
@@ -1506,5 +1507,18 @@ macro_rules! capture_stack {
     (in($cx:expr) let $name:ident ) => {
         rooted!(in($cx) let mut __obj = ::std::ptr::null_mut());
         let $name = $crate::rust::CapturedJSStack::new($cx, __obj, None);
+    }
+}
+
+
+impl Default for PropertyDescriptor {
+    fn default() -> PropertyDescriptor {
+        PropertyDescriptor { 
+            obj: ptr::null_mut(),
+            attrs: 0,
+            getter: None,
+            setter: None,
+            value: UndefinedValue()  
+        }
     }
 }


### PR DESCRIPTION
It is needed for servo to be able to use `JS_GetOwnPropertyDescriptorById` method as it needs `MutableHandle<PropertyDescriptor>` as output parameter. To get the `MutableHandle` one should do sth like `rooted!(in(cx) let mut desc = dummyPropertyDescriptor)` and then `desc.handle_mut()`. Now there are no easy ways to get `dummyPropertyDescriptor`.

I am not sure if it is the proper way. AFAIK the jsapi_* files are automatically generated they shouldn't be modified and I don't know how to make bindgen generate `derive(Default)` for PropertyDescriptor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/407)
<!-- Reviewable:end -->
