### PR TITLE
typedarray: Use a Cell for handling interior mutability.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"


### PR DESCRIPTION
The typed array wrapper has a "computed" option that uses to cache its data.

That means that you need a mutable reference to the typed array in order to read
it, which is not great.

In particular, it's plain impossible when the typed array is provided as a
member of a struct via WebIDL.

Use a `Cell` and expose to_vec and as_slice in non-mutable references.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/408)
<!-- Reviewable:end -->
