### PR TITLE
Use ObjectPrivateVisitor derived class in CollectServoSizes to measure heap usage of DOM objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"

--- a/src/glue.rs
+++ b/src/glue.rs
@@ -261,7 +261,8 @@ extern "C" {
     pub fn AppendToAutoObjectVector(v: *mut AutoObjectVector,
                                     obj: *mut JSObject) -> bool;
     pub fn DeleteAutoObjectVector(v: *mut AutoObjectVector);
-    pub fn CollectServoSizes(rt: *mut JSRuntime, sizes: *mut ServoSizes) -> bool;
+    pub fn CollectServoSizes(rt: *mut JSRuntime, sizes: *mut ServoSizes, get_size: Option<unsafe extern "C" fn (obj: *mut JSObject) -> usize>) -> bool;
+    pub fn InitializeMemoryReporter(want_to_measure: Option<unsafe extern "C" fn (obj: *mut JSObject) -> bool>);
     pub fn CallIdTracer(trc: *mut JSTracer, idp: *mut Heap<jsid>,
                         name: *const ::libc::c_char);
     pub fn CallValueTracer(trc: *mut JSTracer, valuep: *mut Heap<Value>,

--- a/src/jsglue.cpp
+++ b/src/jsglue.cpp
@@ -21,6 +21,11 @@
 #include "js/Principals.h"
 #include "assert.h"
 
+typedef bool(*WantToMeasure)(JSObject *obj);
+typedef size_t(*GetSize)(JSObject *obj);
+
+WantToMeasure gWantToMeasure = nullptr;
+
 struct ProxyTraps {
     bool (*enter)(JSContext *cx, JS::HandleObject proxy, JS::HandleId id,
                   js::BaseProxyHandler::Action action, bool *bp);
@@ -437,6 +442,45 @@ class ForwardingProxyHandler : public js::BaseProxyHandler
     }
 };
 
+class ServoDOMVisitor : public JS::ObjectPrivateVisitor {
+public:
+  size_t sizeOfIncludingThis(nsISupports *aSupports) {
+
+    JSObject* obj = (JSObject*)aSupports;
+    size_t result = 0;
+
+    if (get_size != nullptr && obj != nullptr) {
+      result = (*get_size)(obj);
+    }
+
+    return result;
+  }
+
+  GetSize get_size;
+
+  ServoDOMVisitor(GetSize gs, GetISupportsFun getISupports)
+  : ObjectPrivateVisitor(getISupports)
+  , get_size(gs)
+  {}
+};
+
+bool
+ShouldMeasureObject(JSObject* obj, nsISupports** iface) {
+
+  if (obj == nullptr) {
+    return false;
+  }
+
+  bool want_to_measure = (*gWantToMeasure)(obj);
+
+  if (want_to_measure) {
+    *iface = (nsISupports*)obj;
+    return true;
+  }
+  return false;
+}
+
+
 extern "C" {
 
 JSPrincipals*
@@ -805,11 +849,18 @@ static size_t MallocSizeOf(const void* aPtr)
 }
 
 bool
-CollectServoSizes(JSRuntime *rt, JS::ServoSizes *sizes)
+CollectServoSizes(JSRuntime *rt, JS::ServoSizes *sizes, GetSize gs)
 {
-    mozilla::PodZero(sizes);
-    return JS::AddServoSizeOf(rt, MallocSizeOf,
-                              /* ObjectPrivateVisitor = */ nullptr, sizes);
+  mozilla::PodZero(sizes);
+
+  ServoDOMVisitor sdv(gs, ShouldMeasureObject);
+
+  return JS::AddServoSizeOf(rt, MallocSizeOf, &sdv, sizes);
+}
+
+void
+InitializeMemoryReporter(WantToMeasure wtm){
+  gWantToMeasure = wtm;
 }
 
 void


### PR DESCRIPTION
This PR contains the updates in rust-mozjs necessary for [servo issue 7084](https://github.com/servo/servo/issues/7084). A new class which derives from ObjectPrivateVisitor was added. It is used in CollectServoSizes, with an instance being passed into AddServoSizeOf instead of a nullptr. An additional function was added (InitializeMemoryReporter) which sets the value of a global function pointer, which is used to check if we want to measure the heap usage for a particular JSObject.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/409)
<!-- Reviewable:end -->
