### PR TITLE
Version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"


### PR DESCRIPTION
Needed to use PropertyDescriptor::default in servo. I forgot to do it with earlier commits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/412)
<!-- Reviewable:end -->
