### PR TITLE
Added RootKind and GCMethods implementation for PropertyDescriptor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -316,6 +316,11 @@ impl RootKind for Value {
     fn rootKind() -> jsapi::RootKind { jsapi::RootKind::Value }
 }
 
+impl RootKind for PropertyDescriptor {
+    #[inline(always)]
+    fn rootKind() -> jsapi::RootKind { jsapi::RootKind::Traceable }
+}
+
 // Creates a C string literal `$str`.
 macro_rules! c_str {
     ($str:expr) => {
@@ -973,6 +978,11 @@ impl GCMethods for Value {
     unsafe fn post_barrier(v: *mut Value, prev: Value, next: Value) {
         HeapValuePostBarrier(v, &prev, &next);
     }
+}
+
+impl GCMethods for PropertyDescriptor {
+    unsafe fn initial() -> PropertyDescriptor { PropertyDescriptor::default() }
+    unsafe fn post_barrier(_ : *mut PropertyDescriptor, _ : PropertyDescriptor, _ :PropertyDescriptor) {}
 }
 
 impl<T: GCMethods + Copy> Heap<T> {


### PR DESCRIPTION
It is needed for [servo issue 15012](https://github.com/servo/servo/issues/15012).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/414)
<!-- Reviewable:end -->
