### PR TITLE
Show backtraces on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 script:
   - ccache -z
   - CCACHE=$(which ccache) travis_wait cargo build --verbose $FEATURES
-  - CCACHE=$(which ccache) cargo test --verbose $FEATURES
+  - CCACHE=$(which ccache) RUST_BACKTRACE=1 cargo test --verbose $FEATURES
   - ccache -s
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ environment:
     C:\\Program Files\\Git\\cmd;\
     C:\\Program Files\\Git\\usr\\bin;\
     C:\\Program Files\\AppVeyor\\BuildAgent;"
+  RUST_BACKTRACE: "1"
   matrix:
   - TARGET: nightly-x86_64-pc-windows-msvc
 


### PR DESCRIPTION
https://ci.appveyor.com/project/servo/rust-mozjs/build/1.0.619 is pretty frustrating because it shows no useful information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/415)
<!-- Reviewable:end -->
