### PR TITLE
Implement TypedArray::len

### DIFF
--- a/src/typedarray.rs
+++ b/src/typedarray.rs
@@ -157,6 +157,11 @@ impl<T: TypedArrayElement, S: JSObjectStorage> TypedArray<T, S> {
         data
     }
 
+    /// Returns the number of elements in the underlying typed array.
+    pub fn len(&self) -> usize {
+        self.data().1 as usize
+    }
+
     /// # Unsafety
     ///
     /// Returned wrapped pointer to the underlying `JSObject` is meant to be

--- a/tests/typedarray.rs
+++ b/tests/typedarray.rs
@@ -40,6 +40,9 @@ fn typedarray() {
         assert_eq!(array.unwrap().as_slice(), &[0, 2, 4][..]);
 
         typedarray!(in(cx) let array: Uint8Array = rval.to_object());
+        assert_eq!(array.unwrap().len(), 3);
+
+        typedarray!(in(cx) let array: Uint8Array = rval.to_object());
         assert_eq!(array.unwrap().to_vec(), vec![0, 2, 4]);
 
         typedarray!(in(cx) let array: Uint16Array = rval.to_object());


### PR DESCRIPTION
Fixes #418.

Mimicks [`Vec::len`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.len) signature.

r? @nox