### PR TITLE
Require C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     add_definitions(-Wno-c++0x-extensions -Wno-return-type-c-linkage -Wno-invalid-offsetof)
   endif()
   add_definitions(-fPIC -fno-rtti)
-  add_definitions(-std=c++11 -DJS_NO_JSVAL_JSID_STRUCT_TYPES)
+  add_definitions(-std=c++14 -DJS_NO_JSVAL_JSID_STRUCT_TYPES)
   add_definitions(-include $ENV{DEP_MOZJS_OUTDIR}/js/src/js-confdefs.h)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     add_definitions(-Wno-c++0x-extensions -Wno-return-type-c-linkage -Wno-invalid-offsetof)
   endif()
   add_definitions(-fPIC -fno-rtti)
-  add_definitions(-std=c++14 -DJS_NO_JSVAL_JSID_STRUCT_TYPES)
+  add_definitions(-std=c++1y -DJS_NO_JSVAL_JSID_STRUCT_TYPES)
   add_definitions(-include $ENV{DEP_MOZJS_OUTDIR}/js/src/js-confdefs.h)
 endif()
 


### PR DESCRIPTION
Currently C++14 features are unavailable due to explicit -std=c++11 switch.
See also https://bugzilla.mozilla.org/show_bug.cgi?id=1451931

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/423)
<!-- Reviewable:end -->
