### PR TITLE
Set the cpp flag on the cc builder in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,7 @@ fn main() {
     let outdir = env::var("DEP_MOZJS_OUTDIR").unwrap();
     let include_path: PathBuf = [&outdir, "dist", "include"].iter().collect();
 
-    build
+    build.cpp(true)
         .file("src/jsglue.cpp")
         .include(include_path);
     if env::var("CARGO_FEATURE_DEBUGMOZJS").is_ok() {


### PR DESCRIPTION
Fixes a build error when cross-compiling from linux to android:
```
CC_armv7-linux-androideabi = None
CC_armv7_linux_androideabi = None
HOST_CC = None
CC = None
CFLAGS_armv7-linux-androideabi = None
CFLAGS_armv7_linux_androideabi = None
HOST_CFLAGS = None
CFLAGS = Some("--sysroot /home/servo/android/ndk/r12b/android-ndk-r12b/platforms/android-18/arch-arm -I/home/servo/android/ndk/r12b/android-ndk-r12b/sources/android/support/include")
running: "arm-linux-androideabi-gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "--sysroot" "/home/servo/android/ndk/r12b/android-ndk-r12b/platforms/android-18/arch-arm" "-I/home/servo/android/ndk/r12b/android-ndk-r12b/sources/android/support/include" "-g" "-march=armv7-a" "-march=armv7-a" "-mthumb" "-mfpu=vfpv3-d16" "-mfloat-abi=softfp" "-I" "/home/servo/servo/target/armv7-linux-androideabi/debug/build/mozjs_sys-6ea9cc1d03743689/out/dist/include" "-Wall" "-Wextra" "-fPIC" "-fno-rtti" "-std=c++11" "-include" "/home/servo/servo/target/armv7-linux-androideabi/debug/build/mozjs_sys-6ea9cc1d03743689/out/js/src/js-confdefs.h" "-Wno-c++0x-extensions" "-Wno-return-type-c-linkage" "-Wno-unused-parameter" "-DJS_NO_JSVAL_JSID_STRUCT_TYPES=" "-o" "/home/servo/servo/target/armv7-linux-androideabi/debug/build/mozjs-3864977b9602d849/out/src/jsglue.o" "-c" "src/jsglue.cpp"
cargo:warning=In file included from /home/servo/servo/target/armv7-linux-androideabi/debug/build/mozjs_sys-6ea9cc1d03743689/out/dist/include/mozilla/Attributes.h:12:0,
cargo:warning=                 from /home/servo/servo/target/armv7-linux-androideabi/debug/build/mozjs_sys-6ea9cc1d03743689/out/dist/include/mozilla/Assertions.h:16,
cargo:warning=                 from /home/servo/servo/target/armv7-linux-androideabi/debug/build/mozjs_sys-6ea9cc1d03743689/out/dist/include/mozilla/AlreadyAddRefed.h:12,
cargo:warning=                 from /home/servo/servo/target/armv7-linux-androideabi/debug/build/mozjs_sys-6ea9cc1d03743689/out/dist/include/jsapi.h:12,
cargo:warning=                 from src/jsglue.cpp:15:
cargo:warning=/home/servo/servo/target/armv7-linux-androideabi/debug/build/mozjs_sys-6ea9cc1d03743689/out/dist/include/mozilla/Compiler.h:49:21: fatal error: cstddef: No such file or directory
cargo:warning= #  include <cstddef>
cargo:warning=                     ^
cargo:warning=compilation terminated.
exit code: 1
```
The error shows that the C compiler chain rather than the C++ compiler chain is being used, even though it's compiling a `.cpp` file.