### PR TITLE
Work around inconsistent padding from different LLVM versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"


### PR DESCRIPTION
This allows building with LLVM 4 or 6 and unbreaks my mac cross-compilation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/440)
<!-- Reviewable:end -->
