### PR TITLE
Re-export IntoHandle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -68,7 +68,7 @@ use panic::maybe_resume_unwind;
 
 use default_heapsize;
 
-pub use mozjs_sys::jsgc::GCMethods;
+pub use mozjs_sys::jsgc::{GCMethods, IntoHandle};
 
 // From Gecko:
 // Our "default" stack is what we use in configurations where we don't have a compelling reason to
@@ -1468,4 +1468,4 @@ pub mod jsapi_wrapped {
     include!("jsapi_wrappers.in");
     include!("glue_wrappers.in");
 }
- 
+


### PR DESCRIPTION
When implementing `rejectionhandled` event, we'll need to add consumed rejection in task and we'll need to convert `HandleObject` into `RawHandleObject` which is `js::jsapi::HandleObject`. With exporting this trait, we can leverage the power of `into_handle` to do the conversion instead of writing a new method to get the `RawHandleObject`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/445)
<!-- Reviewable:end -->
