### PR TITLE
Accept a mutable handle in JS_GetPromiseResult.

### DIFF
--- a/src/glue.rs
+++ b/src/glue.rs
@@ -352,7 +352,7 @@ extern "C" {
     pub fn WriteBytesToJSStructuredCloneData(src: *const u8, len: usize, dest: *mut JSStructuredCloneData);
     pub fn JS_ComputeThis (cx: *mut JSContext , vp: *mut JS::Value, dest: *mut JS::Value);
     pub fn JS_GetModuleHostDefinedField (module: *mut JSObject, dest: *mut JS::Value);
-    pub fn JS_GetPromiseResult (promise: JS::HandleObject, dest: *mut JS::Value);
+    pub fn JS_GetPromiseResult (promise: JS::HandleObject, dest: JS::MutableHandleValue);
     pub fn JS_THIS (cx: *mut JSContext , vp: *mut JS::Value, dest: *mut JS::Value);
     pub fn JS_GetNaNValue (cx: *mut JSContext, dest: *mut JS::Value);
     pub fn JS_GetPositiveInfinityValue (cx: *mut JSContext, dest: *mut JS::Value);

--- a/src/glue_wrappers.in
+++ b/src/glue_wrappers.in
@@ -14,5 +14,5 @@ wrap!(glue: pub fn RUST_SYMBOL_TO_JSID(sym: *mut Symbol, id: MutableHandleId));
 wrap!(glue: pub fn int_to_jsid(i: i32, id: MutableHandleId));
 wrap!(glue: pub fn RUST_INTERNED_STRING_TO_JSID(cx: *mut JSContext, str: *mut JSString, id: MutableHandleId));
 wrap!(glue: pub fn AppendToAutoIdVector(v: *mut AutoIdVector, id: HandleId) -> bool);
-wrap!(glue: pub fn JS_GetPromiseResult (promise: HandleObject, dest: *mut Value));
+wrap!(glue: pub fn JS_GetPromiseResult (promise: HandleObject, dest: MutableHandleValue));
 wrap!(glue: pub fn EncodeStringToUTF8(cx: *mut JSContext, str: HandleString, cb: fn(*const c_char)));

--- a/src/jsglue.cpp
+++ b/src/jsglue.cpp
@@ -1036,8 +1036,8 @@ WriteBytesToJSStructuredCloneData(const uint8_t* src, size_t len, JSStructuredCl
 // https://mozilla.logbot.info/jsapi/20180622#c14918658
 
 void
-JS_GetPromiseResult(JS::HandleObject promise, JS::Value* dest) {
-  *dest = JS::GetPromiseResult(promise);
+JS_GetPromiseResult(JS::HandleObject promise, JS::MutableHandleValue dest) {
+  dest.set(JS::GetPromiseResult(promise));
 }
 
 void


### PR DESCRIPTION
This makes it easier to use from calling code that needs to root the result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/470)
<!-- Reviewable:end -->
