### PR TITLE
change the slot count to match the spidermonkey defintion

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -24,4 +24,4 @@ pub const JSCLASS_IS_PROXY: c_uint =
     1 << (JSCLASS_HIGH_FLAGS_SHIFT + 4);
 
 pub const JSCLASS_GLOBAL_SLOT_COUNT: c_uint =
-    JSCLASS_GLOBAL_APPLICATION_SLOTS + JSProtoKey::JSProto_LIMIT as c_uint * 3 + 36;
+    JSCLASS_GLOBAL_APPLICATION_SLOTS + JSProtoKey::JSProto_LIMIT as c_uint * 2 + 38;


### PR DESCRIPTION
right now the slot count is `2 + 38` in the spider monkey fork. this PR changes it to match the C++ definition.

The definition in C++: https://github.com/servo/mozjs/blob/dd175ee73a179ce218286c4be4ab80e1a75348be/mozjs/js/public/Class.h#L841

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/479)
<!-- Reviewable:end -->
