### PR TITLE
use the latest available xcode osx image for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ dist: xenial
 os:
   - linux
   - osx
-osx_image: xcode9.3
+osx_image: xcode11
 
 addons:
   apt:


### PR DESCRIPTION
travis uses xcode 9.3 right now. the default xcode image without a version is 9.4.1. This pr bumps the version to the latest available version which is 11.0.

The available versions are mentioned here:
https://docs.travis-ci.com/user/reference/osx#macos-version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-mozjs/482)
<!-- Reviewable:end -->
