### PR TITLE
Throw when failing to convert sequence inner values

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -641,7 +641,10 @@ impl<C: Clone, T: FromJSValConvertible<Config=C>> FromJSValConvertible for Vec<T
 
             ret.push(match T::from_jsval(cx, val.handle(), option.clone())? {
                 ConversionResult::Success(v) => v,
-                ConversionResult::Failure(e) => return Ok(ConversionResult::Failure(e)),
+                ConversionResult::Failure(e) => {
+                    throw_type_error(cx, &e);
+                    return Err(());
+                },
             });
         }
 


### PR DESCRIPTION
Returning `Ok(ConversionResult::Failure)` allows the code to try other conversion in a union type, but [per the spec there is no such failover](https://heycam.github.io/webidl/#es-union) given that the type is iterable.

For https://github.com/servo/servo/issues/24406.