### PR TITLE
Prevent initializing and shutting down SpiderMonkey from different threads

### DIFF
--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -25,7 +25,7 @@ use std::str;
 #[test]
 fn callback() {
     let engine = JSEngine::init().unwrap();
-    let runtime = Runtime::new(engine);
+    let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();

--- a/tests/capture_stack.rs
+++ b/tests/capture_stack.rs
@@ -22,7 +22,7 @@ use std::ptr;
 #[test]
 fn capture_stack() {
     let engine = JSEngine::init().unwrap();
-    let runtime = Runtime::new(engine);
+    let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();

--- a/tests/custom_auto_rooter.rs
+++ b/tests/custom_auto_rooter.rs
@@ -34,7 +34,7 @@ unsafe impl CustomTrace for TraceCheck {
 #[test]
 fn virtual_trace_called() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine);
+    let rt = Runtime::new(engine.handle());
     let cx = rt.cx();
 
     let mut rooter = CustomAutoRooter::new(TraceCheck::new());

--- a/tests/custom_auto_rooter_macro.rs
+++ b/tests/custom_auto_rooter_macro.rs
@@ -31,7 +31,7 @@ unsafe impl CustomTrace for TraceCheck {
 #[test]
 fn custom_auto_rooter_macro() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine);
+    let rt = Runtime::new(engine.handle());
     let cx = rt.cx();
 
     auto_root!(in(cx) let vec = vec![TraceCheck::new(), TraceCheck::new()]);

--- a/tests/enumerate.rs
+++ b/tests/enumerate.rs
@@ -23,7 +23,7 @@ use std::ptr;
 #[test]
 fn enumerate() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine);
+    let rt = Runtime::new(engine.handle());
     let cx = rt.cx();
     let options = RealmOptions::default();
 

--- a/tests/evaluate.rs
+++ b/tests/evaluate.rs
@@ -15,7 +15,7 @@ use std::ptr;
 #[test]
 fn evaluate() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine);
+    let rt = Runtime::new(engine.handle());
     let cx = rt.cx();
 
     unsafe {

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -20,7 +20,7 @@ use std::ptr;
 #[should_panic]
 fn test_panic() {
     let engine = JSEngine::init().unwrap();
-    let runtime = Runtime::new(engine);
+    let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();

--- a/tests/rooting.rs
+++ b/tests/rooting.rs
@@ -29,7 +29,7 @@ use std::ptr;
 fn rooting() {
     unsafe {
         let engine = JSEngine::init().unwrap();
-        let runtime = Runtime::new(engine);
+        let runtime = Runtime::new(engine.handle());
         let cx = runtime.cx();
         JS_SetGCZeal(cx, 2, 1);
 

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -24,7 +24,7 @@ use std::sync::mpsc::channel;
 fn runtime() {
     let engine = JSEngine::init().unwrap();
     assert!(JSEngine::init().is_err());
-    let runtime = Runtime::new(engine);
+    let runtime = Runtime::new(engine.handle());
     unsafe {
         let cx = runtime.cx();
         let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;

--- a/tests/runtime_no_outlive.rs
+++ b/tests/runtime_no_outlive.rs
@@ -10,7 +10,7 @@ use mozjs::rust::{JSEngine, Runtime};
 #[should_panic]
 fn runtime() {
     let engine = JSEngine::init().unwrap();
-    let runtime = Runtime::new(engine);
+    let runtime = Runtime::new(engine.handle());
     let _parent = runtime.prepare_for_new_child();
     drop(runtime);
 }

--- a/tests/stack_limit.rs
+++ b/tests/stack_limit.rs
@@ -15,7 +15,7 @@ use std::ptr;
 #[test]
 fn stack_limit() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine);
+    let rt = Runtime::new(engine.handle());
     let cx = rt.cx();
 
     unsafe {

--- a/tests/typedarray.rs
+++ b/tests/typedarray.rs
@@ -21,7 +21,7 @@ use std::ptr;
 #[test]
 fn typedarray() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine);
+    let rt = Runtime::new(engine.handle());
     let cx = rt.cx();
 
     unsafe {

--- a/tests/typedarray_panic.rs
+++ b/tests/typedarray_panic.rs
@@ -20,7 +20,7 @@ use std::ptr;
 #[should_panic]
 fn typedarray_update_panic() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine);
+    let rt = Runtime::new(engine.handle());
     let cx = rt.cx();
     let options = RealmOptions::default();
 

--- a/tests/vec_conversion.rs
+++ b/tests/vec_conversion.rs
@@ -21,7 +21,7 @@ use std::ptr;
 #[test]
 fn vec_conversion() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine);
+    let rt = Runtime::new(engine.handle());
     let cx = rt.cx();
 
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;


### PR DESCRIPTION
Based on [this comment](https://github.com/servo/mozjs/blob/e21c05b415dfc246175ff8d5fc48b0e8c5b4e9e9/mozjs/js/public/Initialization.h#L19-L23), it appears that JS_Init and JS_ShutDown need to be called on the same thread. These changes make JSEngine a non-sendable type, and add JSEngineHandle as a sendable type that allows verifying that all outstanding consumers of the engine are dropped before shutting down.