### PR TITLE
Add ToJSValConvertible impls for &T and Box<T>

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -513,6 +513,20 @@ impl<T: ToJSValConvertible> ToJSValConvertible for Option<T> {
     }
 }
 
+impl<T: ToJSValConvertible> ToJSValConvertible for &'_ T {
+    #[inline]
+    unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
+        (**self).to_jsval(cx, rval)
+    }
+}
+
+impl<T: ToJSValConvertible> ToJSValConvertible for Box<T> {
+    #[inline]
+    unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
+        (**self).to_jsval(cx, rval)
+    }
+}
+
 impl<T: ToJSValConvertible> ToJSValConvertible for Rc<T> {
     #[inline]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {


### PR DESCRIPTION
This lets us do things like write a `to_frozen_array()` function that operates on `&[impl ToJSValConvertible]`, agnostic about `&T`, `DomRoot<T>`, or `&Dom<T>`

r? @jdm