### PR TITLE
Update wrappers

### DIFF
--- a/src/jsapi_wrappers.in
+++ b/src/jsapi_wrappers.in
@@ -143,6 +143,13 @@ wrap!(jsapi: pub fn AddPromiseReactions(cx: *mut JSContext, promise: HandleObjec
 wrap!(jsapi: pub fn GetPromiseUserInputEventHandlingState(promise: HandleObject) -> PromiseUserInputEventHandlingState);
 wrap!(jsapi: pub fn SetPromiseUserInputEventHandlingState(promise: HandleObject, state: PromiseUserInputEventHandlingState) -> bool);
 wrap!(jsapi: pub fn GetWaitForAllPromise(cx: *mut JSContext, promises: HandleObjectVector) -> *mut JSObject);
+wrap!(jsapi: pub fn SetRegExpInput(cx: *mut JSContext, obj: HandleObject, input: Handle<*mut JSString>) -> bool);
+wrap!(jsapi: pub fn ClearRegExpStatics(cx: *mut JSContext, obj: HandleObject) -> bool);
+wrap!(jsapi: pub fn ExecuteRegExp(cx: *mut JSContext, obj: HandleObject, reobj: HandleObject, chars: *mut u16, length: usize, indexp: *mut usize, test: bool, rval: MutableHandle<Value>) -> bool);
+wrap!(jsapi: pub fn ExecuteRegExpNoStatics(cx: *mut JSContext, reobj: HandleObject, chars: *const u16, length: usize, indexp: *mut usize, test: bool, rval: MutableHandle<Value>) -> bool);
+wrap!(jsapi: pub fn ObjectIsRegExp(cx: *mut JSContext, obj: HandleObject, isRegExp: *mut bool) -> bool);
+wrap!(jsapi: pub fn GetRegExpFlags(cx: *mut JSContext, obj: HandleObject) -> RegExpFlags);
+wrap!(jsapi: pub fn GetRegExpSource(cx: *mut JSContext, obj: HandleObject) -> *mut JSString);
 wrap!(jsapi: pub fn GetSavedFrameSource(cx: *mut JSContext, principals: *mut JSPrincipals, savedFrame: HandleObject, sourcep: MutableHandle<*mut JSString>, selfHosted: SavedFrameSelfHosted) -> SavedFrameResult);
 wrap!(jsapi: pub fn GetSavedFrameSourceId(cx: *mut JSContext, principals: *mut JSPrincipals, savedFrame: HandleObject, sourceIdp: *mut u32, selfHosted: SavedFrameSelfHosted) -> SavedFrameResult);
 wrap!(jsapi: pub fn GetSavedFrameLine(cx: *mut JSContext, principals: *mut JSPrincipals, savedFrame: HandleObject, linep: *mut u32, selfHosted: SavedFrameSelfHosted) -> SavedFrameResult);

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -55,6 +55,7 @@ use jsapi::HandleValue as RawHandleValue;
 use jsapi::MutableHandle as RawMutableHandle;
 use jsapi::MutableHandleIdVector as RawMutableHandleIdVector;
 use jsapi::glue::{JS_Init, JS_NewRealmOptions, DeleteRealmOptions};
+use jsapi::JS::RegExpFlags;
 #[cfg(feature = "debugmozjs")]
 use jsapi::mozilla::detail::GuardObjectNotificationReceiver;
 use jsapi::mozilla::Utf8Unit;


### PR DESCRIPTION
Add wrappers for RegExp-related functions (introduced by https://github.com/servo/mozjs/commit/7a99ba88598c2c8ca93571e1c753a81469fda57e)