### PR TITLE
Incrementing minor version for underlying source API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mozjs"
 description = "Rust bindings to the Mozilla SpiderMonkey JavaScript engine."
 repository = "https://github.com/servo/rust-mozjs"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
 license = "MPL-2.0"


### PR DESCRIPTION
I forgot to do this in https://github.com/servo/rust-mozjs/pull/495, I guess it is necessary in order to update in Servo?