### PR TITLE
Use dynamic dispatch in `mozjs::panic::wrap_panic`

### DIFF
--- a/src/panic.rs
+++ b/src/panic.rs
@@ -4,7 +4,7 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::panic::{UnwindSafe, catch_unwind, resume_unwind};
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 
 thread_local!(static PANIC_PAYLOAD: RefCell<Option<Box<dyn Any + Send>>> = RefCell::new(None));
 
@@ -16,18 +16,17 @@ pub fn maybe_resume_unwind() {
 }
 
 /// Generic wrapper for JS engine callbacks panic-catching
-pub fn wrap_panic<F, R>(function: F, generic_return_type: R) -> R
-    where F: FnOnce() -> R + UnwindSafe
-{
-    let result = catch_unwind(function);
-    match result {
-        Ok(result) => result,
-        Err(error) => {
-            PANIC_PAYLOAD.with(|result| {
-                assert!(result.borrow().is_none());
-                *result.borrow_mut() = Some(error);
+// https://github.com/servo/servo/issues/26585
+#[inline(never)]
+pub fn wrap_panic(function: &mut dyn FnMut()) {
+    match catch_unwind(AssertUnwindSafe(function)) {
+        Ok(()) => {},
+        Err(payload) => {
+            PANIC_PAYLOAD.with(|opt_payload| {
+                let mut opt_payload = opt_payload.borrow_mut();
+                assert!(opt_payload.is_none());
+                *opt_payload = Some(payload);
             });
-            generic_return_type
         }
     }
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -6,11 +6,11 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::panic::{UnwindSafe, catch_unwind, resume_unwind};
 
-thread_local!(static PANIC_RESULT: RefCell<Option<Box<dyn Any + Send>>> = RefCell::new(None));
+thread_local!(static PANIC_PAYLOAD: RefCell<Option<Box<dyn Any + Send>>> = RefCell::new(None));
 
 /// If there is a pending panic, resume unwinding.
 pub fn maybe_resume_unwind() {
-    if let Some(error) = PANIC_RESULT.with(|result| result.borrow_mut().take()) {
+    if let Some(error) = PANIC_PAYLOAD.with(|result| result.borrow_mut().take()) {
         resume_unwind(error);
     }
 }
@@ -23,7 +23,7 @@ pub fn wrap_panic<F, R>(function: F, generic_return_type: R) -> R
     match result {
         Ok(result) => result,
         Err(error) => {
-            PANIC_RESULT.with(|result| {
+            PANIC_PAYLOAD.with(|result| {
                 assert!(result.borrow().is_none());
                 *result.borrow_mut() = Some(error);
             });

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -42,7 +42,13 @@ fn test_panic() {
 }
 
 unsafe extern "C" fn test(_cx: *mut JSContext, _argc: u32, _vp: *mut Value) -> bool {
-    wrap_panic(|| {
-        panic!()
-    }, false)
+    let mut result = false;
+    wrap_panic(&mut || {
+        panic!();
+        #[allow(unreachable_code)]
+        {
+            result = true
+        }
+    });
+    result
 }


### PR DESCRIPTION
Servo has generated code that calls it with thousands of different closures. With monomorphization, this function alone contributed significantly to code size (millions of lines of unoptimized LLVM IR) and compilation time: https://github.com/servo/servo/issues/26585

By switching to dynamic dispatch, compilation time for Servo’s script crate (which is pathologically long) is reduced by about a quarter on my machine.

Other changes are:

* Removing return value handling, which required a generic type parameter. Instead, the provided callback needs to assign to a captured variable. (See test for an example.)

* The callback needs to implement `FnMut` rather than only `FnOnce`. We could instead take `Box<dyn FnOnce() + '_>` (with allocation overhead), but none of the callers is affected.

* The `UnwindSafe` constraint is removed, because multi-trait objects do not support up-casting yet. It wasn’t much help anyway  since the code generator always used `AssertUnwindSafe` regardless of what each closure does.

Dynamic dispatch has non-zero runtime cost. Perhaps here it is small enough, or compensated by better instruction cache utilization thanks to reduced code size?