### PR TITLE
Pass StackCapture argument by pointer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,4 @@ lazy_static = "1"
 libc = "0.2"
 log = "0.4"
 num-traits = "0.2"
-mozjs_sys = { git = "https://github.com/servo/mozjs", rev = "9a6d8fc6b0cf13cd02efbd805ccdf62ddc5ce593" }
+mozjs_sys = { git = "https://github.com/servo/mozjs", rev = "fc8b31502fb9bc0cc229f1fd4493c4a0de5239a3" }


### PR DESCRIPTION
This avoids a crash on Windows arm64. Depends on https://github.com/servo/mozjs/pull/253.