### PR TITLE
Add glue methods to get JSValue of a private reference

### DIFF
--- a/src/glue.rs
+++ b/src/glue.rs
@@ -367,6 +367,8 @@ extern "C" {
     pub fn JS_ComputeThis (cx: *mut JSContext , vp: *mut JS::Value, dest: *mut JS::Value);
     pub fn JS_GetModuleHostDefinedField (module: *mut JSObject, dest: *mut JS::Value);
     pub fn JS_GetPromiseResult (promise: JS::HandleObject, dest: JS::MutableHandleValue);
+    pub fn JS_GetScriptPrivate(script: *mut JSScript, dest: JS::MutableHandleValue);
+    pub fn JS_GetModulePrivate(module: *mut JSObject, dest: JS::MutableHandleValue);
     pub fn JS_THIS (cx: *mut JSContext , vp: *mut JS::Value, dest: *mut JS::Value);
     pub fn JS_GetNaNValue (cx: *mut JSContext, dest: *mut JS::Value);
     pub fn JS_GetPositiveInfinityValue (cx: *mut JSContext, dest: *mut JS::Value);

--- a/src/glue_wrappers.in
+++ b/src/glue_wrappers.in
@@ -17,4 +17,6 @@ wrap!(glue: pub fn RUST_INTERNED_STRING_TO_JSID(cx: *mut JSContext, str: *mut JS
 wrap!(glue: pub fn GetIdVectorAddress(v: *mut PersistentRootedIdVector) -> *mut ::libc::c_void);
 wrap!(glue: pub fn AppendToIdVector(v: MutableHandleIdVector, id: HandleId) -> bool);
 wrap!(glue: pub fn JS_GetPromiseResult (promise: HandleObject, dest: MutableHandleValue));
+wrap!(glue: pub fn JS_GetScriptPrivate(script: *mut JSScript, dest: MutableHandleValue));
+wrap!(glue: pub fn JS_GetModulePrivate(module: *mut JSObject, dest: MutableHandleValue));
 wrap!(glue: pub fn EncodeStringToUTF8(cx: *mut JSContext, str: HandleString, cb: fn(*const c_char)));

--- a/src/jsglue.cpp
+++ b/src/jsglue.cpp
@@ -19,6 +19,7 @@
 #include "js/Class.h"
 #include "js/Id.h"
 #include "js/MemoryMetrics.h"
+#include "js/Modules.h"  // include for JS::GetModulePrivate
 #include "js/Principals.h"
 #include "js/Promise.h"
 #include "js/Proxy.h"
@@ -1075,6 +1076,16 @@ WriteBytesToJSStructuredCloneData(const uint8_t* src, size_t len, JSStructuredCl
 void
 JS_GetPromiseResult(JS::HandleObject promise, JS::MutableHandleValue dest) {
   dest.set(JS::GetPromiseResult(promise));
+}
+
+void
+JS_GetScriptPrivate(JSScript* script, JS::MutableHandleValue dest) {
+    dest.set(JS::GetScriptPrivate(script));
+}
+
+void
+JS_GetModulePrivate(JSObject* module, JS::MutableHandleValue dest) {
+    dest.set(JS::GetModulePrivate(module));
 }
 
 void


### PR DESCRIPTION
While working on servo/servo#27026, we've noticed calling
`GetScriptPrivate` will hit a CRASH consistently in Windows. jdm noticed
that this is caused by "can't return JSValue by value on Windows"; thus,
we need to expose these 2 glue methods so that we can handle the
`GetScriptPrivate` and `GetModulePrivate` correctly.

---

This will help servo/servo#27026.

We might want to handle the `ModulePrivate` much more correctly in the future so it might be worth adding it here as well?