### PR TITLE
rust.rs: unsafe Handle::new() is now a private function.

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -767,7 +767,7 @@ impl<'a, T> Handle<'a, T> {
         *self.ptr
     }
 
-    pub fn new(ptr: &'a T) -> Self {
+    fn new(ptr: &'a T) -> Self {
         Handle { ptr: ptr }
     }
 


### PR DESCRIPTION
The new() constructor is unsafe because of the way it accepts pointers 
and isn't marked to indicate this. The usage occurrence of this function 
outside of this crate is also limited to one. To thisend, marking it private 
would prevent potentially unsafe propagation.