### PR TITLE
Updated to include support for macOS 11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,4 @@ lazy_static = "1"
 libc = "0.2"
 log = "0.4"
 num-traits = "0.2"
-mozjs_sys = { git = "https://github.com/servo/mozjs", rev = "b1ddeefa55dcff606285a1df077d8fec1384c825" }
+mozjs_sys = { git = "https://github.com/servo/mozjs", rev = "26a1e8afdb21beec33373ef2a38131272d064bdd" }


### PR DESCRIPTION
Based on [this issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1682608), it looks like we can update mozjs to support up to macOS 11.1.

