### PR TITLE
Add `ProxyTraps::{getPrototype, setPrototype, setImmutablePrototype}`

### DIFF
--- a/src/glue.rs
+++ b/src/glue.rs
@@ -134,6 +134,24 @@ pub struct ProxyTraps {
             protop: MutableHandleObject,
         ) -> bool,
     >,
+    pub getPrototype: ::std::option::Option<
+        unsafe extern "C" fn(
+            cx: *mut JSContext,
+            proxy: HandleObject,
+            protop: MutableHandleObject,
+        ) -> bool,
+    >,
+    pub setPrototype: ::std::option::Option<
+        unsafe extern "C" fn(
+            cx: *mut JSContext,
+            proxy: HandleObject,
+            proto: HandleObject,
+            result: *mut ObjectOpResult,
+        ) -> bool,
+    >,
+    pub setImmutablePrototype: ::std::option::Option<
+        unsafe extern "C" fn(cx: *mut JSContext, proxy: HandleObject, succeeded: *mut bool) -> bool,
+    >,
     pub preventExtensions: ::std::option::Option<
         unsafe extern "C" fn(
             cx: *mut JSContext,

--- a/src/jsglue.cpp
+++ b/src/jsglue.cpp
@@ -149,9 +149,13 @@ struct ProxyTraps {
 
     bool (*getPrototypeIfOrdinary)(JSContext *cx, JS::HandleObject proxy,
                                    bool *isOrdinary, JS::MutableHandleObject protop);
-    // getPrototype
-    // setPrototype
-    // setImmutablePrototype
+    bool (*getPrototype)(JSContext *cx, JS::HandleObject proxy,
+                         JS::MutableHandleObject protop);
+    bool (*setPrototype)(JSContext *cx, JS::HandleObject proxy,
+                         JS::HandleObject proto,
+                         JS::ObjectOpResult &result);
+    bool (*setImmutablePrototype)(JSContext *cx, JS::HandleObject proxy,
+                                  bool *succeeded);
 
     bool (*preventExtensions)(JSContext *cx, JS::HandleObject proxy,
                               JS::ObjectOpResult &result);
@@ -349,6 +353,31 @@ static int HandlerFamily;
         return mTraps.isConstructor                                                          \
                    ? mTraps.isConstructor(obj)                                               \
                    : _base::isConstructor(obj);                                              \
+    }                                                                                        \
+                                                                                             \
+    virtual bool getPrototype(JSContext* cx, JS::HandleObject proxy,                         \
+                              JS::MutableHandleObject protop) const override                 \
+    {                                                                                        \
+        return mTraps.getPrototype                                                           \
+                   ? mTraps.getPrototype(cx, proxy, protop)                                  \
+                   : _base::getPrototype(cx, proxy, protop);                                 \
+    }                                                                                        \
+                                                                                             \
+    virtual bool setPrototype(JSContext* cx, JS::HandleObject proxy,                         \
+                              JS::HandleObject proto,                                        \
+                              JS::ObjectOpResult& result)  const override                    \
+    {                                                                                        \
+        return mTraps.setPrototype                                                           \
+                   ? mTraps.setPrototype(cx, proxy, proto, result)                           \
+                   : _base::setPrototype(cx, proxy, proto, result);                          \
+    }                                                                                        \
+                                                                                             \
+    virtual bool setImmutablePrototype(JSContext* cx, JS::HandleObject proxy,                \
+                                       bool* succeeded) const override                       \
+    {                                                                                        \
+        return mTraps.setImmutablePrototype                                                  \
+                   ? mTraps.setImmutablePrototype(cx, proxy, succeeded)                      \
+                   : _base::setImmutablePrototype(cx, proxy, succeeded);                     \
     }
 
 class WrapperProxyHandler : public js::Wrapper


### PR DESCRIPTION
The `WindowProxy` exotic object requires a dynamic, non-ordinary [`[[GetPrototypeOf]]`](https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-getprototypeof).

Cf. <https://searchfox.org/mozilla-central/rev/9c9f2f85d00aef1943cb521ac95c72bae932ebc5/dom/base/MaybeCrossOriginObject.cpp#356-373>

