### PR TITLE
Add a "lazy prototype" parameter to `NewProxyObject`

### DIFF
--- a/src/glue.rs
+++ b/src/glue.rs
@@ -380,6 +380,7 @@ extern "C" {
         aPriv: HandleValue,
         proto: *mut JSObject,
         classp: *const JSClass,
+        aLazyProto: bool,
     ) -> *mut JSObject;
     pub fn WrapperNew(
         aCx: *mut JSContext,

--- a/src/glue_wrappers.in
+++ b/src/glue_wrappers.in
@@ -3,7 +3,7 @@ wrap!(glue: pub fn InvokeHasOwn(handler: *const ::libc::c_void, cx: *mut JSConte
 wrap!(glue: pub fn CallJitGetterOp(info: *const JSJitInfo, cx: *mut JSContext, thisObj: HandleObject, specializedThis: *mut ::libc::c_void, argc: u32, vp: *mut Value) -> bool);
 wrap!(glue: pub fn CallJitSetterOp(info: *const JSJitInfo, cx: *mut JSContext, thisObj: HandleObject, specializedThis: *mut ::libc::c_void, argc: u32, vp: *mut Value) -> bool);
 wrap!(glue: pub fn CallJitMethodOp(info: *const JSJitInfo, cx: *mut JSContext, thisObj: HandleObject, specializedThis: *mut ::libc::c_void, argc: u32, vp: *mut Value) -> bool);
-wrap!(glue: pub fn NewProxyObject(aCx: *mut JSContext, aHandler: *const ::libc::c_void, aPriv: HandleValue, proto: *mut JSObject, classp: *const JSClass) -> *mut JSObject);
+wrap!(glue: pub fn NewProxyObject(aCx: *mut JSContext, aHandler: *const ::libc::c_void, aPriv: HandleValue, proto: *mut JSObject, classp: *const JSClass, aLazyProto: bool) -> *mut JSObject);
 wrap!(glue: pub fn WrapperNew(aCx: *mut JSContext, aObj: HandleObject, aHandler: *const ::libc::c_void, aClass: *const JSClass, aSingleton: bool) -> *mut JSObject);
 wrap!(glue: pub fn NewWindowProxy(aCx: *mut JSContext, aObj: HandleObject, aHandler: *const ::libc::c_void) -> *mut JSObject);
 wrap!(glue: pub fn RUST_JSID_IS_INT(id: HandleId) -> bool);

--- a/src/jsglue.cpp
+++ b/src/jsglue.cpp
@@ -719,12 +719,13 @@ NewCompileOptions(
 
 JSObject*
 NewProxyObject(JSContext* aCx, const void* aHandler, JS::HandleValue aPriv,
-               JSObject* proto, JSClass* aClass)
+               JSObject* proto, JSClass* aClass, bool aLazyProto)
 {
     js::ProxyOptions options;
     if (aClass) {
       options.setClass(aClass);
     }
+    options.setLazyProto(aLazyProto);
     return js::NewProxyObject(aCx, (js::BaseProxyHandler*)aHandler, aPriv, proto,
                               options);
 }


### PR DESCRIPTION
This PR introduces a new parameter `aLazyProto` to the `NewProxyObject`, where its value is passed to `js::ProxyOptions::setLazyProto`.

Setting the lazy proto option allows proxy handlers to provide dynamic prototype objects. This is necessary for maybe-cross-origin objects, whose [`[[GetPrototypeOf]]`][1] internal methods have a dynamic behavior.

[1]: https://html.spec.whatwg.org/multipage/history.html#location-getprototypeof