### PR TITLE
Added Test for Property Descriptor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ name = "evaluate"
 [[test]]
 name = "panic"
 [[test]]
+name = "property_descriptor"
+[[test]]
 name = "rooting"
 [[test]]
 name = "runtime"

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -23,7 +23,6 @@ use std::slice;
 use std::str;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
-use std::u32;
 
 use consts::{JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_RESERVED_SLOTS_MASK};
 use consts::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
@@ -1516,7 +1515,6 @@ pub mod wrappers {
     use jsapi::JSStructuredCloneData;
     use jsapi::JSType;
     use jsapi::MutableHandleIdVector;
-    use jsapi::PersistentRootedIdVector;
     use jsapi::PromiseState;
     use jsapi::PromiseUserInputEventHandlingState;
     use jsapi::ReadOnlyCompileOptions;
@@ -1662,7 +1660,6 @@ pub mod jsapi_wrapped {
     use jsapi::JSStructuredCloneData;
     use jsapi::JSType;
     use jsapi::MutableHandleIdVector;
-    use jsapi::PersistentRootedIdVector;
     use jsapi::PromiseState;
     use jsapi::PromiseUserInputEventHandlingState;
     use jsapi::ReadOnlyCompileOptions;

--- a/tests/custom_auto_rooter.rs
+++ b/tests/custom_auto_rooter.rs
@@ -40,7 +40,7 @@ fn virtual_trace_called() {
     let guard = rooter.root(context);
 
     unsafe {
-        JS_GC(cx, GCReason::API);
+        JS_GC(context, GCReason::API);
     }
 
     assert!(guard.trace_was_called.get());

--- a/tests/custom_auto_rooter.rs
+++ b/tests/custom_auto_rooter.rs
@@ -3,14 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate mozjs;
-use mozjs::jsapi::GCReason;
-use mozjs::jsapi::JSTracer;
-use mozjs::jsapi::JS_GC;
-use mozjs::rust::CustomAutoRooter;
-use mozjs::rust::CustomTrace;
-use mozjs::rust::JSEngine;
-use mozjs::rust::Runtime;
+
 use std::cell::Cell;
+
+use mozjs::jsapi::{GCReason, JSTracer, JS_GC};
+use mozjs::rust::{CustomAutoRooter, CustomTrace, JSEngine, Runtime};
 
 struct TraceCheck {
     trace_was_called: Cell<bool>,
@@ -36,11 +33,11 @@ unsafe impl CustomTrace for TraceCheck {
 #[test]
 fn virtual_trace_called() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine.handle());
-    let cx = rt.cx();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.cx();
 
     let mut rooter = CustomAutoRooter::new(TraceCheck::new());
-    let guard = rooter.root(cx);
+    let guard = rooter.root(context);
 
     unsafe {
         JS_GC(cx, GCReason::API);

--- a/tests/custom_auto_rooter_macro.rs
+++ b/tests/custom_auto_rooter_macro.rs
@@ -34,10 +34,10 @@ fn custom_auto_rooter_macro() {
     let runtime = Runtime::new(engine.handle());
     let context = runtime.cx();
 
-    auto_root!(in(cx) let vec = vec![TraceCheck::new(), TraceCheck::new()]);
+    auto_root!(in(context) let vec = vec![TraceCheck::new(), TraceCheck::new()]);
 
     unsafe {
-        JS_GC(cx, GCReason::API);
+        JS_GC(context, GCReason::API);
     }
 
     vec.iter()

--- a/tests/custom_auto_rooter_macro.rs
+++ b/tests/custom_auto_rooter_macro.rs
@@ -4,13 +4,11 @@
 
 #[macro_use]
 extern crate mozjs;
-use mozjs::jsapi::GCReason;
-use mozjs::jsapi::JSTracer;
-use mozjs::jsapi::JS_GC;
-use mozjs::rust::CustomTrace;
-use mozjs::rust::JSEngine;
-use mozjs::rust::Runtime;
+
 use std::cell::Cell;
+
+use mozjs::jsapi::{GCReason, JSTracer, JS_GC};
+use mozjs::rust::{CustomTrace, JSEngine, Runtime};
 
 struct TraceCheck {
     trace_was_called: Cell<bool>,
@@ -33,8 +31,8 @@ unsafe impl CustomTrace for TraceCheck {
 #[test]
 fn custom_auto_rooter_macro() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine.handle());
-    let cx = rt.cx();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.cx();
 
     auto_root!(in(cx) let vec = vec![TraceCheck::new(), TraceCheck::new()]);
 

--- a/tests/enumerate.rs
+++ b/tests/enumerate.rs
@@ -30,8 +30,8 @@ fn enumerate() {
             &*c_option,
         ));
 
-        rooted!(in(cx) let mut rval = UndefinedValue());
-        assert!(rt
+        rooted!(in(context) let mut rval = UndefinedValue());
+        assert!(runtime
             .evaluate_script(
                 global.handle(),
                 "({ 'a': 7 })",
@@ -42,24 +42,24 @@ fn enumerate() {
             .is_ok());
         assert!(rval.is_object());
 
-        rooted!(in(cx) let object = rval.to_object());
-        let mut ids = IdVector::new(cx);
+        rooted!(in(context) let object = rval.to_object());
+        let mut ids = IdVector::new(context);
         assert!(GetPropertyKeys(
-            cx,
+            context,
             object.handle().into(),
             JSITER_OWNONLY,
             ids.handle_mut(),
         ));
 
         assert_eq!(ids.len(), 1);
-        rooted!(in(cx) let id = ids[0]);
+        rooted!(in(context) let id = ids[0]);
 
         assert!(RUST_JSID_IS_STRING(id.handle().into()));
-        rooted!(in(cx) let id = RUST_JSID_TO_STRING(id.handle().into()));
+        rooted!(in(context) let id = RUST_JSID_TO_STRING(id.handle().into()));
 
         let mut matches = false;
         assert!(JS_StringEqualsAscii(
-            cx,
+            context,
             id.get(),
             b"a\0" as *const _ as *const _,
             &mut matches

--- a/tests/evaluate.rs
+++ b/tests/evaluate.rs
@@ -28,10 +28,10 @@ fn evaluate() {
             &*c_option,
         ));
 
-        rooted!(in(cx) let mut rval = UndefinedValue());
-        assert!(rt
+        rooted!(in(context) let mut rval = UndefinedValue());
+        assert!(runtime
             .evaluate_script(global.handle(), "1 + 1", "test", 1, rval.handle_mut())
             .is_ok());
-        assert_eq!(rval.get().to_number(), 2);
+        assert_eq!(rval.get().to_int32(), 2);
     }
 }

--- a/tests/evaluate.rs
+++ b/tests/evaluate.rs
@@ -5,29 +5,33 @@
 #[macro_use]
 extern crate mozjs;
 
-use mozjs::jsapi::JS_NewGlobalObject;
-use mozjs::jsapi::OnNewGlobalHookOption;
+use std::ptr;
+
+use mozjs::jsapi::{JS_NewGlobalObject, OnNewGlobalHookOption};
 use mozjs::jsval::UndefinedValue;
 use mozjs::rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
-
-use std::ptr;
 
 #[test]
 fn evaluate() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine.handle());
-    let cx = rt.cx();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.cx();
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = RealmOptions::default();
 
     unsafe {
-        let options = RealmOptions::default();
-        rooted!(in(cx) let global =
-            JS_NewGlobalObject(cx, &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
-                               OnNewGlobalHookOption::FireOnNewGlobalHook,
-                               &*options)
-        );
+        rooted!(in(context) let global = JS_NewGlobalObject(
+            context,
+            &SIMPLE_GLOBAL_CLASS,
+            ptr::null_mut(),
+            h_option,
+            &*c_option,
+        ));
+
         rooted!(in(cx) let mut rval = UndefinedValue());
         assert!(rt
             .evaluate_script(global.handle(), "1 + 1", "test", 1, rval.handle_mut())
             .is_ok());
+        assert_eq!(rval.get().to_number(), 2);
     }
 }

--- a/tests/property_descriptor.rs
+++ b/tests/property_descriptor.rs
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[macro_use]
+extern crate mozjs;
+extern crate mozjs_sys;
+
+use std::ptr;
+
+use mozjs::jsapi::{JS_NewGlobalObject, JS_NewPlainObject, FromPropertyDescriptor, JS_DefineProperty, JS_GetPropertyDescriptor};
+use mozjs::jsapi::{JSPROP_ENUMERATE, JSPROP_READONLY, JSPROP_PERMANENT};
+use mozjs::jsapi::{JSAutoRealm, OnNewGlobalHookOption, PropertyDescriptor};
+use mozjs::jsval::{Int32Value, NullValue};
+use mozjs::rust::{JSEngine, Runtime, RealmOptions, SIMPLE_GLOBAL_CLASS};
+use mozjs_sys::jsapi::JS_GetProperty;
+
+#[test]
+fn property_descriptor() {
+    let engine = JSEngine::init().unwrap();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.cx();
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = RealmOptions::default();
+
+    unsafe {
+        rooted!(in(context) let global = JS_NewGlobalObject(
+            context,
+            &SIMPLE_GLOBAL_CLASS,
+            ptr::null_mut(),
+            h_option,
+            &*c_option,
+        ));
+        let _ac = JSAutoRealm::new(context, global.get());
+
+        rooted!(in(context) let object = JS_NewPlainObject(context));
+        rooted!(in(context) let property = Int32Value(32));
+
+        let attrs = (JSPROP_ENUMERATE | JSPROP_PERMANENT | JSPROP_READONLY) as u32;
+        assert!(JS_DefineProperty(context, object.handle().into(), b"property\0" as *const u8 as *const libc::c_char, property.handle().into(), attrs));
+
+        rooted!(in(context) let mut descriptor: PropertyDescriptor);
+
+        assert!(JS_GetPropertyDescriptor(context, object.handle().into(), b"property\0" as *const u8 as *const libc::c_char, descriptor.handle_mut().into()));
+        assert_eq!(descriptor.get().attrs, attrs);
+        assert_eq!(descriptor.get().value.to_int32(), 32);
+
+        rooted!(in(context) let mut desc = NullValue());
+        assert!(FromPropertyDescriptor(context, descriptor.handle().into(), desc.handle_mut().into()));
+        rooted!(in(context) let desc_object = desc.to_object());
+
+        rooted!(in(context) let mut rval = NullValue());
+        assert!(JS_GetProperty(context, desc_object.handle().into(), b"value\0" as *const u8 as *const libc::c_char, rval.handle_mut().into()));
+        assert_eq!(rval.get().to_int32(), 32);
+        assert!(JS_GetProperty(context, desc_object.handle().into(), b"configurable\0" as *const u8 as *const libc::c_char, rval.handle_mut().into()));
+        assert!(!rval.get().to_boolean());
+        assert!(JS_GetProperty(context, desc_object.handle().into(), b"enumerable\0" as *const u8 as *const libc::c_char, rval.handle_mut().into()));
+        assert!(rval.get().to_boolean());
+        assert!(JS_GetProperty(context, desc_object.handle().into(), b"writable\0" as *const u8 as *const libc::c_char, rval.handle_mut().into()));
+        assert!(!rval.get().to_boolean());
+    }
+}

--- a/tests/rooting.rs
+++ b/tests/rooting.rs
@@ -30,7 +30,7 @@ fn rooting() {
     let c_option = RealmOptions::default();
 
     unsafe {
-        JS_SetGCZeal(cx, 2, 1);
+        JS_SetGCZeal(context, 2, 1);
         rooted!(in(context) let global = JS_NewGlobalObject(
             context,
             &SIMPLE_GLOBAL_CLASS,
@@ -40,20 +40,20 @@ fn rooting() {
         ));
         let _ac = JSAutoRealm::new(context, global.get());
 
-        rooted!(in(cx) let prototype_proto = GetRealmObjectPrototype(context));
-        rooted!(in(cx) let proto = JS_NewObjectWithGivenProto(context, &CLASS as *const _, prototype_proto.handle().into()));
-        define_methods(cx, proto.handle(), METHODS).unwrap();
+        rooted!(in(context) let prototype_proto = GetRealmObjectPrototype(context));
+        rooted!(in(context) let proto = JS_NewObjectWithGivenProto(context, &CLASS as *const _, prototype_proto.handle().into()));
+        define_methods(context, proto.handle(), METHODS).unwrap();
 
-        rooted!(in(cx) let root: JSVal);
+        rooted!(in(context) let root: JSVal);
         assert_eq!(root.get().is_undefined(), true);
 
-        rooted!(in(cx) let root: *mut JSObject);
+        rooted!(in(context) let root: *mut JSObject);
         assert_eq!(root.get().is_null(), true);
 
-        rooted!(in(cx) let root: *mut JSString);
+        rooted!(in(context) let root: *mut JSString);
         assert_eq!(root.get().is_null(), true);
 
-        rooted!(in(cx) let root: *mut JSFunction);
+        rooted!(in(context) let root: *mut JSFunction);
         assert_eq!(root.get().is_null(), true);
     }
 }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -2,39 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate libc;
 #[macro_use]
 extern crate mozjs;
-extern crate libc;
 
-use mozjs::jsapi::JSAutoRealm;
-use mozjs::jsapi::JSClass;
-use mozjs::jsapi::JSClassOps;
-use mozjs::jsapi::JSFreeOp;
-use mozjs::jsapi::JSObject;
-use mozjs::jsapi::JS_NewGlobalObject;
-use mozjs::jsapi::JS_NewObject;
-use mozjs::jsapi::OnNewGlobalHookOption;
-use mozjs::jsapi::JSCLASS_FOREGROUND_FINALIZE;
-use mozjs::rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
 use std::ptr;
 use std::sync::mpsc::channel;
 use std::thread;
 
+use mozjs::jsapi::JSCLASS_FOREGROUND_FINALIZE;
+use mozjs::jsapi::{JSAutoRealm, JSClass, JSClassOps, JSFreeOp, JSObject, OnNewGlobalHookOption};
+use mozjs::jsapi::{JS_NewGlobalObject, JS_NewObject};
+use mozjs::rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
+
 #[test]
 fn runtime() {
     let engine = JSEngine::init().unwrap();
-    assert!(JSEngine::init().is_err());
     let runtime = Runtime::new(engine.handle());
-    unsafe {
-        let cx = runtime.cx();
-        let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
-        let c_option = RealmOptions::default();
+    let context = runtime.cx();
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = RealmOptions::default();
 
-        rooted!(in(cx) let global = JS_NewGlobalObject(cx,
-                                                       &SIMPLE_GLOBAL_CLASS,
-                                                       ptr::null_mut(),
-                                                       h_option,
-                                                       &*c_option));
+    unsafe {
+        rooted!(in(context) let global = JS_NewGlobalObject(
+            context,
+            &SIMPLE_GLOBAL_CLASS,
+            ptr::null_mut(),
+            h_option,
+            &*c_option,
+        ));
         let _ac = JSAutoRealm::new(cx, global.get());
         rooted!(in(cx) let _object = JS_NewObject(cx, &CLASS as *const _));
     }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -31,8 +31,8 @@ fn runtime() {
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(cx, global.get());
-        rooted!(in(cx) let _object = JS_NewObject(cx, &CLASS as *const _));
+        let _ac = JSAutoRealm::new(context, global.get());
+        rooted!(in(context) let _object = JS_NewObject(context, &CLASS as *const _));
     }
 
     let parent = runtime.prepare_for_new_child();

--- a/tests/stack_limit.rs
+++ b/tests/stack_limit.rs
@@ -27,8 +27,8 @@ fn stack_limit() {
             h_option,
             &*c_option,
         ));
-        rooted!(in(cx) let mut rval = UndefinedValue());
-        assert!(rt
+        rooted!(in(context) let mut rval = UndefinedValue());
+        assert!(runtime
             .evaluate_script(
                 global.handle(),
                 "function f() { f.apply() } f()",

--- a/tests/typedarray.rs
+++ b/tests/typedarray.rs
@@ -16,7 +16,7 @@ use mozjs::typedarray::{CreateWith, Uint32Array};
 fn typedarray() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
-    let context = runtime.context();
+    let context = runtime.cx();
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
@@ -31,7 +31,7 @@ fn typedarray() {
         let _ac = JSAutoRealm::new(context, global.get());
 
         rooted!(in(context) let mut rval = UndefinedValue());
-        assert!(rt
+        assert!(runtime
             .evaluate_script(
                 global.handle(),
                 "new Uint8Array([0, 2, 4])",

--- a/tests/typedarray.rs
+++ b/tests/typedarray.rs
@@ -5,36 +5,32 @@
 #[macro_use]
 extern crate mozjs;
 
-use mozjs::jsapi::JSAutoRealm;
-use mozjs::jsapi::JSObject;
-use mozjs::jsapi::JS_NewGlobalObject;
-use mozjs::jsapi::OnNewGlobalHookOption;
-use mozjs::jsapi::Type;
-use mozjs::jsval::UndefinedValue;
-use mozjs::rust::JSEngine;
-use mozjs::rust::RealmOptions;
-use mozjs::rust::Runtime;
-use mozjs::rust::SIMPLE_GLOBAL_CLASS;
-use mozjs::typedarray::{CreateWith, Uint32Array};
 use std::ptr;
+
+use mozjs::jsapi::{JSAutoRealm, JSObject, JS_NewGlobalObject, OnNewGlobalHookOption, Type};
+use mozjs::jsval::UndefinedValue;
+use mozjs::rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
+use mozjs::typedarray::{CreateWith, Uint32Array};
 
 #[test]
 fn typedarray() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine.handle());
-    let cx = rt.cx();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.context();
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = RealmOptions::default();
 
     unsafe {
-        let options = RealmOptions::default();
-        rooted!(in(cx) let global =
-            JS_NewGlobalObject(cx, &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
-                               OnNewGlobalHookOption::FireOnNewGlobalHook,
-                               &*options)
-        );
+        rooted!(in(context) let global = JS_NewGlobalObject(
+            context,
+            &SIMPLE_GLOBAL_CLASS,
+            ptr::null_mut(),
+            h_option,
+            &*c_option,
+        ));
+        let _ac = JSAutoRealm::new(context, global.get());
 
-        let _ac = JSAutoRealm::new(cx, global.get());
-
-        rooted!(in(cx) let mut rval = UndefinedValue());
+        rooted!(in(context) let mut rval = UndefinedValue());
         assert!(rt
             .evaluate_script(
                 global.handle(),
@@ -46,49 +42,51 @@ fn typedarray() {
             .is_ok());
         assert!(rval.is_object());
 
-        typedarray!(in(cx) let array: Uint8Array = rval.to_object());
+        typedarray!(in(context) let array: Uint8Array = rval.to_object());
         assert_eq!(array.unwrap().as_slice(), &[0, 2, 4][..]);
 
-        typedarray!(in(cx) let array: Uint8Array = rval.to_object());
+        typedarray!(in(context) let array: Uint8Array = rval.to_object());
         assert_eq!(array.unwrap().len(), 3);
 
-        typedarray!(in(cx) let array: Uint8Array = rval.to_object());
+        typedarray!(in(context) let array: Uint8Array = rval.to_object());
         assert_eq!(array.unwrap().to_vec(), vec![0, 2, 4]);
 
-        typedarray!(in(cx) let array: Uint16Array = rval.to_object());
+        typedarray!(in(context) let array: Uint16Array = rval.to_object());
         assert!(array.is_err());
 
-        typedarray!(in(cx) let view: ArrayBufferView = rval.to_object());
+        typedarray!(in(context) let view: ArrayBufferView = rval.to_object());
         assert_eq!(view.unwrap().get_array_type(), Type::Uint8);
 
-        rooted!(in(cx) let mut rval = ptr::null_mut::<JSObject>());
-        assert!(Uint32Array::create(cx, CreateWith::Slice(&[1, 3, 5]), rval.handle_mut()).is_ok());
+        rooted!(in(context) let mut rval = ptr::null_mut::<JSObject>());
+        assert!(
+            Uint32Array::create(context, CreateWith::Slice(&[1, 3, 5]), rval.handle_mut()).is_ok()
+        );
 
-        typedarray!(in(cx) let array: Uint32Array = rval.get());
+        typedarray!(in(context) let array: Uint32Array = rval.get());
         assert_eq!(array.unwrap().as_slice(), &[1, 3, 5][..]);
 
-        typedarray!(in(cx) let mut array: Uint32Array = rval.get());
+        typedarray!(in(context) let mut array: Uint32Array = rval.get());
         array.as_mut().unwrap().update(&[2, 4, 6]);
         assert_eq!(array.unwrap().as_slice(), &[2, 4, 6][..]);
 
-        rooted!(in(cx) let rval = ptr::null_mut::<JSObject>());
-        typedarray!(in(cx) let array: Uint8Array = rval.get());
+        rooted!(in(context) let rval = ptr::null_mut::<JSObject>());
+        typedarray!(in(context) let array: Uint8Array = rval.get());
         assert!(array.is_err());
 
-        rooted!(in(cx) let mut rval = ptr::null_mut::<JSObject>());
-        assert!(Uint32Array::create(cx, CreateWith::Length(5), rval.handle_mut()).is_ok());
+        rooted!(in(context) let mut rval = ptr::null_mut::<JSObject>());
+        assert!(Uint32Array::create(context, CreateWith::Length(5), rval.handle_mut()).is_ok());
 
-        typedarray!(in(cx) let array: Uint32Array = rval.get());
+        typedarray!(in(context) let array: Uint32Array = rval.get());
         assert_eq!(array.unwrap().as_slice(), &[0, 0, 0, 0, 0]);
 
-        typedarray!(in(cx) let mut array: Uint32Array = rval.get());
+        typedarray!(in(context) let mut array: Uint32Array = rval.get());
         array.as_mut().unwrap().update(&[0, 1, 2, 3]);
         assert_eq!(array.unwrap().as_slice(), &[0, 1, 2, 3, 0]);
 
-        typedarray!(in(cx) let view: ArrayBufferView = rval.get());
+        typedarray!(in(context) let view: ArrayBufferView = rval.get());
         assert_eq!(view.unwrap().get_array_type(), Type::Uint32);
 
-        typedarray!(in(cx) let view: ArrayBufferView = rval.get());
+        typedarray!(in(context) let view: ArrayBufferView = rval.get());
         assert_eq!(view.unwrap().is_shared(), false);
     }
 }

--- a/tests/typedarray_panic.rs
+++ b/tests/typedarray_panic.rs
@@ -16,23 +16,23 @@ use mozjs::typedarray::{CreateWith, Uint32Array};
 fn typedarray_update_panic() {
     let engine = JSEngine::init().unwrap();
     let runtime = Runtime::new(engine.handle());
-    let context = runtime.context();
+    let context = runtime.cx();
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
         rooted!(in(context) let global = JS_NewGlobalObject(
-            cx,
+            context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
         ));
-        let _ac = JSAutoRealm::new(cx, global.get());
+        let _ac = JSAutoRealm::new(context, global.get());
 
-        rooted!(in(cx) let mut rval = ptr::null_mut::<JSObject>());
-        let _ = Uint32Array::create(cx, CreateWith::Slice(&[1, 2, 3, 4, 5]), rval.handle_mut());
-        typedarray!(in(cx) let mut array: Uint32Array = rval.get());
+        rooted!(in(context) let mut rval = ptr::null_mut::<JSObject>());
+        let _ = Uint32Array::create(context, CreateWith::Slice(&[1, 2, 3, 4, 5]), rval.handle_mut());
+        typedarray!(in(context) let mut array: Uint32Array = rval.get());
         array.as_mut().unwrap().update(&[0, 2, 4, 6, 8, 10]);
     }
 }

--- a/tests/typedarray_panic.rs
+++ b/tests/typedarray_panic.rs
@@ -5,33 +5,31 @@
 #[macro_use]
 extern crate mozjs;
 
-use mozjs::jsapi::JSAutoRealm;
-use mozjs::jsapi::JSObject;
-use mozjs::jsapi::JS_NewGlobalObject;
-use mozjs::jsapi::OnNewGlobalHookOption;
-use mozjs::rust::JSEngine;
-use mozjs::rust::RealmOptions;
-use mozjs::rust::Runtime;
-use mozjs::rust::SIMPLE_GLOBAL_CLASS;
-use mozjs::typedarray::{CreateWith, Uint32Array};
 use std::ptr;
+
+use mozjs::jsapi::{JSAutoRealm, JSObject, JS_NewGlobalObject, OnNewGlobalHookOption};
+use mozjs::rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
+use mozjs::typedarray::{CreateWith, Uint32Array};
 
 #[test]
 #[should_panic]
 fn typedarray_update_panic() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine.handle());
-    let cx = rt.cx();
-    let options = RealmOptions::default();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.context();
+    let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
+    let c_option = RealmOptions::default();
 
     unsafe {
-        rooted!(in(cx) let global =
-            JS_NewGlobalObject(cx, &SIMPLE_GLOBAL_CLASS, ptr::null_mut(),
-                               OnNewGlobalHookOption::FireOnNewGlobalHook,
-                               &*options)
-        );
-
+        rooted!(in(context) let global = JS_NewGlobalObject(
+            cx,
+            &SIMPLE_GLOBAL_CLASS,
+            ptr::null_mut(),
+            h_option,
+            &*c_option,
+        ));
         let _ac = JSAutoRealm::new(cx, global.get());
+
         rooted!(in(cx) let mut rval = ptr::null_mut::<JSObject>());
         let _ = Uint32Array::create(cx, CreateWith::Slice(&[1, 2, 3, 4, 5]), rval.handle_mut());
         typedarray!(in(cx) let mut array: Uint32Array = rval.get());

--- a/tests/vec_conversion.rs
+++ b/tests/vec_conversion.rs
@@ -5,67 +5,70 @@
 #[macro_use]
 extern crate mozjs;
 
-use mozjs::conversions::ConversionBehavior;
-use mozjs::conversions::ConversionResult;
-use mozjs::conversions::FromJSValConvertible;
-use mozjs::conversions::ToJSValConvertible;
-use mozjs::jsapi::InitRealmStandardClasses;
-use mozjs::jsapi::JSAutoRealm;
-use mozjs::jsapi::JS_NewGlobalObject;
-use mozjs::jsapi::OnNewGlobalHookOption;
+use std::ptr;
+
+use mozjs::conversions::{
+    ConversionBehavior, ConversionResult, FromJSValConvertible, ToJSValConvertible,
+};
+use mozjs::jsapi::{
+    InitRealmStandardClasses, JSAutoRealm, JS_NewGlobalObject, OnNewGlobalHookOption,
+};
 use mozjs::jsval::UndefinedValue;
 use mozjs::rust::{JSEngine, RealmOptions, Runtime, SIMPLE_GLOBAL_CLASS};
-
-use std::ptr;
 
 #[test]
 fn vec_conversion() {
     let engine = JSEngine::init().unwrap();
-    let rt = Runtime::new(engine.handle());
-    let cx = rt.cx();
+    let runtime = Runtime::new(engine.handle());
+    let context = runtime.cx();
 
     let h_option = OnNewGlobalHookOption::FireOnNewGlobalHook;
     let c_option = RealmOptions::default();
 
     unsafe {
-        let global = JS_NewGlobalObject(
-            cx,
+        rooted!(in(context) let global = JS_NewGlobalObject(
+            context,
             &SIMPLE_GLOBAL_CLASS,
             ptr::null_mut(),
             h_option,
             &*c_option,
-        );
-        rooted!(in(cx) let global_root = global);
-        let global = global_root.handle();
+        ));
+        let _ac = JSAutoRealm::new(context, global.get());
+        assert!(InitRealmStandardClasses(context));
 
-        let _ac = JSAutoRealm::new(cx, global.get());
-        assert!(InitRealmStandardClasses(cx));
-
-        rooted!(in(cx) let mut rval = UndefinedValue());
+        rooted!(in(context) let mut rval = UndefinedValue());
 
         let orig_vec: Vec<f32> = vec![1.0, 2.9, 3.0];
-        orig_vec.to_jsval(cx, rval.handle_mut());
-        let converted = Vec::<f32>::from_jsval(cx, rval.handle(), ()).unwrap();
+        orig_vec.to_jsval(context, rval.handle_mut());
+        let converted = Vec::<f32>::from_jsval(context, rval.handle(), ()).unwrap();
 
         assert_eq!(&orig_vec, converted.get_success_value().unwrap());
 
         let orig_vec: Vec<i32> = vec![1, 2, 3];
-        orig_vec.to_jsval(cx, rval.handle_mut());
+        orig_vec.to_jsval(context, rval.handle_mut());
         let converted =
-            Vec::<i32>::from_jsval(cx, rval.handle(), ConversionBehavior::Default).unwrap();
+            Vec::<i32>::from_jsval(context, rval.handle(), ConversionBehavior::Default).unwrap();
 
         assert_eq!(&orig_vec, converted.get_success_value().unwrap());
 
-        rt.evaluate_script(global, "new Set([1, 2, 3])", "test", 1, rval.handle_mut())
-            .unwrap();
+        assert!(runtime
+            .evaluate_script(
+                global.handle(),
+                "new Set([1, 2, 3])",
+                "test",
+                1,
+                rval.handle_mut()
+            )
+            .is_ok());
         let converted =
-            Vec::<i32>::from_jsval(cx, rval.handle(), ConversionBehavior::Default).unwrap();
+            Vec::<i32>::from_jsval(context, rval.handle(), ConversionBehavior::Default).unwrap();
 
         assert_eq!(&orig_vec, converted.get_success_value().unwrap());
 
-        rt.evaluate_script(global, "({})", "test", 1, rval.handle_mut())
-            .unwrap();
-        let converted = Vec::<i32>::from_jsval(cx, rval.handle(), ConversionBehavior::Default);
+        assert!(runtime
+            .evaluate_script(global.handle(), "({})", "test", 1, rval.handle_mut())
+            .is_ok());
+        let converted = Vec::<i32>::from_jsval(context, rval.handle(), ConversionBehavior::Default);
         assert!(match converted {
             Ok(ConversionResult::Failure(_)) => true,
             _ => false,


### PR DESCRIPTION
This pull request adds a test for functions using property descriptors.

This test was created on request of @sagudev. I believe the request was to allow for testing when changes in the JSAPI that occurred in SM 90/91. The changes caused these functions to use `mozilla::Maybe`.