### PR TITLE
chore(ci): relink `python3` to `python3.9` on Homebrew

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         .\MozillaBuildSetup.exe /S | Out-Null
         iwr -useb get.scoop.sh -outfile 'install.ps1'
         .\install.ps1 -RunAsAdmin
-        scoop install llvm@13.0.1 --global
+        scoop install llvm@14.0.6 --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     # TODO: Remove this step when the compatibility issue between mozjs and
     #       Homebrew's Python 3.10 formula (servo/rust-mozjs#559) is truly fixed

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,16 @@ jobs:
         .\install.ps1 -RunAsAdmin
         scoop install llvm@13.0.1 --global
         echo "C:\ProgramData\scoop\shims;C:\Users\runneradmin\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    # TODO: Remove this step when the compatibility issue between mozjs and
+    #       Homebrew's Python 3.10 formula (servo/rust-mozjs#559) is truly fixed
+    - name: Select Python 3.9
+      if: startsWith(matrix.os, 'macOS')
+      run: |
+        brew install python@3.9
+        cd $(dirname $(which python3.9))
+        rm -f python3 pip3
+        ln -s python3.9 python3
+        ln -s pip3.9 pip3
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal


### PR DESCRIPTION
Work around the other part of #559